### PR TITLE
fix: Use createRequire for JSON import compatibility

### DIFF
--- a/src/common/version.ts
+++ b/src/common/version.ts
@@ -1,4 +1,7 @@
-import pkg from "../../package.json" with { type: "json" };
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json");
 
 export function getVersion() {
   return pkg.version;


### PR DESCRIPTION
### Description
This pull request fixes a runtime error in `plane-mcp-server` with Node.js versions prior to v21. The error occurs due to JSON import assertion syntax (`import ... with { type: "json" }`) in `src/common/version.ts`, which causes a `SyntaxError: Unexpected token 'with'` on earlier Node.js versions.

The fix replaces the import assertion with Node.js's built-in `createRequire` function from the `node:module` module, making the code compatible with LTS versions (v18, v20) without requiring experimental flags.

This was breaking applications using older versions of Node.js.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->
N/A - This is a code change to fix a runtime error.

### Test Scenarios
<!-- Please describe the tests that you ran to verify your changes -->
1. Ran `npm run build` successfully
2. Verified code runs without errors on Node.js v20.9.0
3. Verified backwards compatibility with Node.js v21+
4. Passed all lint checks (`npm run lint`)

### References
<!-- Link related issues if there are any -->
* [Node.js Documentation on createRequire](https://nodejs.org/api/module.html#modulecreaterequirefilename)
* [Node.js Documentation on JSON modules](https://nodejs.org/api/modules.html#json-modules)