### PR TITLE
chore: add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+"on":
+  push:
+    branches:
+      - main
+permissions:
+  contents: read # for checkout
+jobs:
+  release:
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Verify signatures
+        run: npm audit signatures
+      - name: Build
+        run: npm run build
+      - name: Release
+        # pinned version updated automatically by Renovate.
+        # details at https://semantic-release.gitbook.io/semantic-release/usage/installation#global-installation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release@24

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makeplane/plane-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.1-semantically-released",
   "description": "The Plane MCP Server is a Model Context Protocol (MCP) server that provides seamless integration with Plane APIs, enabling projects, work items, and automations capabilities for develops and AI interfaces.",
   "bin": {
     "plane-mcp-server": "./build/index.js"
@@ -50,5 +50,17 @@
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "zod": "^3.24.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "release": {
+    "branches": ["main"],
+    "plugins": [
+      ["@semantic-release/commit-analyzer", { "preset": "conventionalcommits" }],
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/npm",
+      "@semantic-release/github"
+    ]
   }
 }


### PR DESCRIPTION
### Description
Adds a Github Action to fully [automate releases](https://semantic-release.gitbook.io/semantic-release) whenever new commits land on `main`. The new version is determined based on commit messages ([see conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)).

#### How releases will work:
- Once a PR is merged, this Github Action inspects the new commit messages to determine the appropriate semver version (major, minor, patch)
- A new github and npm release will be created using the determined version

#### Notes
- We are following the [recommendations of the `semantic-release` project](https://semantic-release.gitbook.io/semantic-release/support/faq#why-is-the-package.jsons-version-not-updated-in-my-repository), which means the package.json 
`version` field will _not_ be updated after release. We will use either npm or github (source of truth) to view version history.
- `semantic-release` also supports release channels like alpha/beta which may be useful in the future but not necessary today

#### Plan

If this works as intended, I will open another PR to remove `.github/workflows/publish.yml` which will no longer be needed. I will also add the appropriate husky rules to enforce conventionalcommits format when committing code.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [x] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

### Test Scenarios 
<!-- Please describe the tests that you ran to verify your changes -->

### References
- https://semantic-release.gitbook.io/semantic-release
- https://www.conventionalcommits.org/en/v1.0.0