### PR TITLE
docs: add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Plane MCP Server is a Model Context Protocol (MCP) server that provides seamless integration with Plane APIs, enabling projects, work items, and automations capabilities for develops and AI interfaces.
 
+<a href="https://glama.ai/mcp/servers/@makeplane/plane-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@makeplane/plane-mcp-server/badge" alt="Plane Server MCP server" />
+</a>
+
 ## Use Cases
 
 - Create, update Projects and Work items


### PR DESCRIPTION
This PR adds a badge for the [Plane MCP Server](https://glama.ai/mcp/servers/@makeplane/plane-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@makeplane/plane-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@makeplane/plane-mcp-server/badge" alt="Plane Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.