### PR TITLE
#19 Updating json handling to fix mcp for self hosted instances

### DIFF
--- a/src/common/request-helper.ts
+++ b/src/common/request-helper.ts
@@ -5,20 +5,27 @@ export async function makePlaneRequest<T>(method: string, path: string, body: an
   const host = hostUrl.endsWith("/") ? hostUrl : `${hostUrl}/`;
   const url = `${host}api/v1/${path}`;
   const headers: Record<string, string> = {
-    "Content-Type": "application/json",
     "X-API-Key": process.env.PLANE_API_KEY || "",
   };
+
+  // Only add Content-Type for non-GET requests
+  if (method.toUpperCase() !== 'GET') {
+    headers["Content-Type"] = "application/json";
+  }
 
   try {
     const config: AxiosRequestConfig = {
       url,
       method,
       headers,
-      data: body,
     };
 
-    const response = await axios(config);
+    // Only include body for non-GET requests
+    if (method.toUpperCase() !== 'GET' && body !== null) {
+      config.data = body;
+    }
 
+    const response = await axios(config);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {


### PR DESCRIPTION
### Description
Fixed issues with the `makePlaneRequest` function to properly handle GET requests versus non-GET requests. The changes ensure that the Content-Type header is only included for non-GET requests, and that the request body is only included for non-GET requests when it's not null.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
<!-- Add screenshots to help explain your changes, ideally showcasing before and after -->

Before:
![image](https://github.com/user-attachments/assets/d685a534-7c47-4067-8021-2b10c598d081)

After:
![image](https://github.com/user-attachments/assets/2a06200b-2dc4-46a9-9b51-e32f7bb2815f)

### Test Scenarios 
Tested changes by:
- Running `npx @modelcontextprotocol/inspector --config "path/to/build/index.js" --server plane` and verifying that tools work correctly
- Successfully interacting with Plane via Claude desktop

The changes fix how HTTP requests are built when interacting with the Plane API, ensuring proper behavior with GET and non-GET requests.

### References
<!-- Link related issues if there are any -->
https://github.com/makeplane/plane-mcp-server/issues/19