### PR TITLE
feat: add project issue listing tool

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import { registerIssueTools } from "./issues.js";
 import { registerMetadataTools } from "./metadata.js";
 import { registerModuleIssueTools } from "./module-issues.js";
 import { registerModuleTools } from "./modules.js";
+import { registerProjectIssueTools } from "./project-issues.js";
 import { registerProjectTools } from "./projects.js";
 import { registerUserTools } from "./user.js";
 import { registerWorkLogTools } from "./work-log.js";
@@ -15,6 +16,7 @@ export const registerTools = (server: McpServer) => {
   registerUserTools(server);
 
   registerProjectTools(server);
+  registerProjectIssueTools(server);
   registerModuleTools(server);
   registerModuleIssueTools(server);
   registerIssueTools(server);

--- a/src/tools/project-issues.ts
+++ b/src/tools/project-issues.ts
@@ -1,0 +1,28 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { makePlaneRequest } from "../common/request-helper.js";
+
+export const registerProjectIssueTools = (server: McpServer): void => {
+  server.tool(
+    "list_project_issues",
+    "Get all issues for a specific project",
+    {
+      project_id: z.string().describe("The uuid identifier of the project to get issues for"),
+    },
+    async ({ project_id }) => {
+      const response = await makePlaneRequest(
+        "GET",
+        `workspaces/${process.env.PLANE_WORKSPACE_SLUG}/projects/${project_id}/issues/`
+      );
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(response, null, 2),
+          },
+        ],
+      };
+    }
+  );
+};


### PR DESCRIPTION
  This PR adds a new tool to list all issues for a specific project.
  
  ## Changes
  - Added `list_project_issues` tool in `src/tools/project-issues.ts`
  - Updated `src/tools/index.ts` to register the new tool
  - The tool accepts a `project_id` parameter and returns all issues for that project
  
  ## Usage
  The tool can be used to retrieve all issues associated with a specific project using the project's UUID identifier.
  
  ## Testing
  - [ ] Tool has been tested with valid project IDs
  - [ ] Error handling works correctly for invalid project IDs
  - [ ] Response format matches expected structure