### PR TITLE
chore: Add Gh Workflow for docker image builds

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -1,0 +1,139 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: "Type of build to run"
+        required: true
+        type: choice
+        default: "Build"
+        options:
+          - "Build"
+          - "Release"
+      releaseVersion:
+        description: "Release Version"
+        type: string
+        default: v0.0.0
+      isPrerelease:
+        description: "Is Pre-release"
+        type: boolean
+        default: false
+        required: true
+
+env:
+  TARGET_BRANCH: ${{ github.ref_name }}
+  BUILD_TYPE: ${{ github.event.inputs.build_type }}
+  RELEASE_VERSION: ${{ github.event.inputs.releaseVersion }}
+  IS_PRERELEASE: ${{ github.event.inputs.isPrerelease }}
+
+jobs:
+  release_build_setup:
+    name: Release Build Setup
+    runs-on: ubuntu-22.04
+    outputs:
+      gh_buildx_driver: ${{ steps.set_env_variables.outputs.BUILDX_DRIVER }}
+      gh_buildx_version: ${{ steps.set_env_variables.outputs.BUILDX_VERSION }}
+      gh_buildx_platforms: ${{ steps.set_env_variables.outputs.BUILDX_PLATFORMS }}
+      gh_buildx_endpoint: ${{ steps.set_env_variables.outputs.BUILDX_ENDPOINT }}
+
+      build_type: ${{steps.set_env_variables.outputs.BUILD_TYPE}}
+      build_release: ${{ steps.set_env_variables.outputs.BUILD_RELEASE }}
+      build_prerelease: ${{ steps.set_env_variables.outputs.BUILD_PRERELEASE }}
+      release_version: ${{ steps.set_env_variables.outputs.RELEASE_VERSION }}
+
+      dh_img_name: ${{ steps.set_env_variables.outputs.DH_IMG_NAME }}
+
+    steps:
+      - id: set_env_variables
+        name: Set Environment Variables
+        run: |
+          echo "BUILDX_DRIVER=docker-container" >> $GITHUB_OUTPUT
+          echo "BUILDX_VERSION=latest" >> $GITHUB_OUTPUT
+          echo "BUILDX_PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+          echo "BUILDX_ENDPOINT=" >> $GITHUB_OUTPUT
+
+          echo "DH_IMG_NAME=plane-mcp-server" >> $GITHUB_OUTPUT
+
+          echo "BUILD_TYPE=${{env.BUILD_TYPE}}" >> $GITHUB_OUTPUT
+          BUILD_RELEASE=false
+          BUILD_PRERELEASE=false
+          RELVERSION="latest"
+
+          if [ "${{ env.BUILD_TYPE }}" == "Release" ]; then
+            FLAT_RELEASE_VERSION=$(echo "${{ env.RELEASE_VERSION }}" | sed 's/[^a-zA-Z0-9.-]//g')
+            echo "FLAT_RELEASE_VERSION=${FLAT_RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+            semver_regex="^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)?$"
+            if [[ ! $FLAT_RELEASE_VERSION =~ $semver_regex ]]; then
+              echo "Invalid Release Version Format : $FLAT_RELEASE_VERSION"
+              echo "Please provide a valid SemVer version"
+              echo "e.g. v1.2.3 or v1.2.3-alpha-1"
+              echo "Exiting the build process"
+              exit 1  # Exit with status 1 to fail the step
+            fi
+            BUILD_RELEASE=true
+            RELVERSION=$FLAT_RELEASE_VERSION
+
+            if [ "${{ env.IS_PRERELEASE }}" == "true" ]; then
+              BUILD_PRERELEASE=true
+            fi
+          fi
+          echo "BUILD_RELEASE=${BUILD_RELEASE}" >> $GITHUB_OUTPUT
+          echo "BUILD_PRERELEASE=${BUILD_PRERELEASE}" >> $GITHUB_OUTPUT
+          echo "RELEASE_VERSION=${RELVERSION}" >> $GITHUB_OUTPUT
+
+  build_and_push:
+    name: Build-Push Plane MCP Server Docker Image
+    runs-on: ubuntu-22.04
+    needs: [release_build_setup]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - id: checkout_files
+        name: Checkout Files
+        uses: actions/checkout@v4
+      - name: Plane MCP Server Build and Push
+        uses: makeplane/actions/build-push@v1.0.0
+        with:
+          build-release: ${{ needs.release_build_setup.outputs.build_release }}
+          build-prerelease: ${{ needs.release_build_setup.outputs.build_prerelease }}
+          release-version: ${{ needs.release_build_setup.outputs.release_version }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-image-owner: makeplane
+          docker-image-name: ${{ needs.release_build_setup.outputs.dh_img_name }}
+          build-context: .
+          dockerfile-path: ./Dockerfile
+          buildx-driver: ${{ needs.release_build_setup.outputs.gh_buildx_driver }}
+          buildx-version: ${{ needs.release_build_setup.outputs.gh_buildx_version }}
+          buildx-platforms: ${{ needs.release_build_setup.outputs.gh_buildx_platforms }}
+          buildx-endpoint: ${{ needs.release_build_setup.outputs.gh_buildx_endpoint }}
+
+  publish_release:
+    if: ${{ needs.release_build_setup.outputs.build_type == 'Release' }}
+    name: Build Release
+    runs-on: ubuntu-22.04
+    needs:
+      [
+        release_build_setup,
+        build_and_push,
+      ]
+    env:
+      REL_VERSION: ${{ needs.release_build_setup.outputs.release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ env.REL_VERSION }}
+          name: ${{ env.REL_VERSION }}
+          draft: false
+          prerelease: ${{ env.IS_PRERELEASE }}
+          generate_release_notes: true


### PR DESCRIPTION
### Description
<!-- Provide a detailed description of the changes in this PR -->
This pull request introduces a new GitHub Actions workflow for building, pushing, and releasing Docker images for the Plane MCP Server. The workflow is designed to handle both regular and release builds, including pre-releases, and automates the release process with validation for semantic versioning.


### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [X] Improvement (change that would cause existing functionality to not work as expected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated Docker image building and release publishing infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->