### PR TITLE
chore: use internal base URL for API client

### DIFF
--- a/plane_mcp/client.py
+++ b/plane_mcp/client.py
@@ -28,7 +28,8 @@ def get_plane_client_context() -> PlaneClientContext:
     3. OAuth access token
 
     Environment variables:
-    - PLANE_BASE_URL: Base URL for Plane API (default: https://api.plane.so)
+    - PLANE_INTERNAL_BASE_URL: Internal URL for Plane API (preferred for server-to-server calls)
+    - PLANE_BASE_URL: Base URL for Plane API (fallback, default: https://api.plane.so)
 
     Returns:
         PlaneClientContext containing configured PlaneClient instance and workspace slug
@@ -36,7 +37,9 @@ def get_plane_client_context() -> PlaneClientContext:
     Raises:
         ConfigurationError: If access token is not available or workspace slug is missing
     """
-    base_url = os.getenv("PLANE_BASE_URL", "https://api.plane.so")
+    base_url = os.getenv("PLANE_INTERNAL_BASE_URL") or os.getenv(
+        "PLANE_BASE_URL", "https://api.plane.so"
+    )
     workspace_slug = os.getenv("PLANE_WORKSPACE_SLUG", "")
 
     api_key = os.getenv("PLANE_API_KEY", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plane-mcp-server"
-version = "0.2.2"
+version = "0.2.3"
 description = "A Model Context Protocol server for Plane integration"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Description
Route PlaneClient API calls through PLANE_INTERNAL_BASE_URL when available, falling back to PLANE_BASE_URL.

### Type of Change
- [X] Improvement (change that would cause existing functionality to not work as expected)

### Test Scenarios 
- Verified in local by setting the env variables using mcp inspector


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.3
  * Enhanced API base URL resolution to prioritize internal endpoint configuration when available, with automatic fallback to default settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->