### PR TITLE
feat: auto-expand assignees in work item queries

### DIFF
--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -178,6 +178,13 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         """
         client, workspace_slug = get_plane_client_context()
 
+        # Always expand assignees to get UserLite objects instead of bare UUIDs.
+        if expand:
+            if "assignees" not in expand:
+                expand = f"{expand},assignees"
+        else:
+            expand = "assignees"
+
         params = RetrieveQueryParams(
             expand=expand,
             fields=fields,
@@ -220,6 +227,13 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             WorkItemDetail object with expanded relationships
         """
         client, workspace_slug = get_plane_client_context()
+
+        # Always expand assignees to get UserLite objects instead of bare UUIDs.
+        if expand:
+            if "assignees" not in expand:
+                expand = f"{expand},assignees"
+        else:
+            expand = "assignees"
 
         params = RetrieveQueryParams(
             expand=expand,


### PR DESCRIPTION
## Summary
- Always include `assignees` in the `expand` parameter for `get_work_item` and `list_work_items`
- Returns `UserLite` objects with display names instead of bare UUIDs
- Avoids the need for a follow-up members API call to resolve assignee names

## Changes
- `plane_mcp/tools/work_items.py`: Added assignee expansion logic to both `get_work_item` and `list_work_items` functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Work item retrieval operations now consistently return complete assignee information, ensuring user details are always available when fetching work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->