### PR TITLE
feat: add PLANE_MCP_MODULES env flag to restrict loaded tools

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -14,3 +14,17 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # PLANE_OAUTH_PROVIDER_CLIENT_ID=your_oauth_client_id
 # PLANE_OAUTH_PROVIDER_CLIENT_SECRET=your_oauth_client_secret
 # PLANE_OAUTH_PROVIDER_BASE_URL=http://localhost:8211
+
+# Optional: Restrict which tool modules are loaded (comma-separated).
+# Use 'all' or leave unset to load every module (109 tools).
+# Available modules:
+#   projects, work_items, work_item_activities, work_item_comments,
+#   work_item_links, work_item_relations, work_item_types, work_item_properties,
+#   work_logs, cycles, modules, epics, milestones, initiatives, intake,
+#   labels, pages, states, users, workspaces
+#
+# Minimal set example (~30 tools):
+# PLANE_MCP_MODULES=projects,work_items,states,labels,users,workspaces,epics
+#
+# Default (all modules):
+# PLANE_MCP_MODULES=all

--- a/README.md
+++ b/README.md
@@ -125,6 +125,62 @@ export PLANE_WORKSPACE_SLUG="your-workspace-slug"
 
 **Note**: For remote HTTP transports (OAuth or PAT), authentication is handled via the connection method (OAuth flow or PAT headers) and does not require these environment variables.
 
+### Restricting Loaded Tools (`PLANE_MCP_MODULES`)
+
+By default the server registers **all 109 tools**. If you want to reduce the
+number of tools exposed to the AI (e.g. to stay within a client's tool limit or
+to keep the context focused), set the `PLANE_MCP_MODULES` environment variable
+to a comma-separated list of module names.
+
+| Value | Behaviour |
+|-------|-----------|
+| `all` (default) | Every module is loaded — all 109 tools |
+| `projects,work_items,...` | Only the listed modules are loaded |
+
+**Available module names:**
+
+| Module | # Tools | Description |
+|--------|---------|-------------|
+| `projects` | 9 | Project CRUD + members, features, worklog summary |
+| `work_items` | 7 | Issue CRUD + search |
+| `states` | 5 | Workflow state CRUD |
+| `labels` | 5 | Label CRUD |
+| `epics` | 5 | Epic CRUD |
+| `cycles` | 12 | Cycle CRUD + archive/transfer/work-item management |
+| `modules` | 11 | Module CRUD + archive/work-item management |
+| `milestones` | 8 | Milestone CRUD + work-item management |
+| `work_item_comments` | 5 | Comment CRUD on issues |
+| `work_item_links` | 5 | External link CRUD on issues |
+| `work_item_relations` | 3 | Issue relation management (blocks, duplicates…) |
+| `work_item_types` | 5 | Custom issue type CRUD |
+| `work_item_properties` | 5 | Custom property CRUD |
+| `work_item_activities` | 2 | Read-only activity/audit log |
+| `work_logs` | 4 | Time-tracking log CRUD |
+| `initiatives` | 5 | Initiative CRUD (Enterprise feature) |
+| `intake` | 5 | Intake/triage issue CRUD |
+| `pages` | 4 | Workspace and project page management |
+| `users` | 1 | Current user info |
+| `workspaces` | 3 | Workspace members and feature flags |
+
+**Minimal set example** (~30 tools, stdio config):
+
+```json
+{
+  "mcpServers": {
+    "plane": {
+      "command": "uvx",
+      "args": ["plane-mcp-server", "stdio"],
+      "env": {
+        "PLANE_API_KEY": "<your-api-key>",
+        "PLANE_WORKSPACE_SLUG": "<your-workspace-slug>",
+        "PLANE_BASE_URL": "https://api.plane.so",
+        "PLANE_MCP_MODULES": "projects,work_items,states,labels,users,workspaces,epics"
+      }
+    }
+  }
+}
+```
+
 ## Available Tools
 
 The server provides comprehensive tools for interacting with Plane. All tools use Pydantic models from the Plane SDK for type safety and validation.

--- a/plane_mcp/tools/__init__.py
+++ b/plane_mcp/tools/__init__.py
@@ -1,5 +1,8 @@
 """Tools for Plane MCP Server."""
 
+import logging
+import os
+
 from fastmcp import FastMCP
 
 from plane_mcp.tools.cycles import register_cycle_tools
@@ -23,26 +26,92 @@ from plane_mcp.tools.work_items import register_work_item_tools
 from plane_mcp.tools.work_logs import register_work_log_tools
 from plane_mcp.tools.workspaces import register_workspace_tools
 
+logger = logging.getLogger(__name__)
+
+# All available modules and their register functions.
+# Keys are the module names used in PLANE_MCP_MODULES env var.
+_ALL_MODULES: dict[str, tuple[callable, int]] = {
+    # (register_fn, tool_count)
+    "projects":               (register_project_tools,              9),
+    "work_items":             (register_work_item_tools,             7),
+    "work_item_activities":   (register_work_item_activity_tools,    2),
+    "work_item_comments":     (register_work_item_comment_tools,     5),
+    "work_item_links":        (register_work_item_link_tools,        5),
+    "work_item_relations":    (register_work_item_relation_tools,    3),
+    "work_item_types":        (register_work_item_type_tools,        5),
+    "work_item_properties":   (register_work_item_property_tools,    5),
+    "work_logs":              (register_work_log_tools,              4),
+    "cycles":                 (register_cycle_tools,                12),
+    "modules":                (register_module_tools,               11),
+    "epics":                  (register_epic_tools,                  5),
+    "milestones":             (register_milestone_tools,             8),
+    "initiatives":            (register_initiative_tools,            5),
+    "intake":                 (register_intake_tools,                5),
+    "labels":                 (register_label_tools,                 5),
+    "pages":                  (register_page_tools,                  4),
+    "states":                 (register_state_tools,                 5),
+    "users":                  (register_user_tools,                  1),
+    "workspaces":             (register_workspace_tools,             3),
+}
+
+
+def _get_enabled_modules() -> set[str] | None:
+    """
+    Read the PLANE_MCP_MODULES environment variable.
+
+    Returns:
+        None  → load all modules (default, backward-compatible)
+        set   → only load the listed modules
+
+    Examples:
+        PLANE_MCP_MODULES=all                              → all 109 tools
+        PLANE_MCP_MODULES=projects,work_items,states,...   → selected modules only
+    """
+    raw = os.getenv("PLANE_MCP_MODULES", "all").strip()
+    if raw.lower() == "all":
+        return None
+    enabled = {m.strip() for m in raw.split(",") if m.strip()}
+    unknown = enabled - _ALL_MODULES.keys()
+    if unknown:
+        logger.warning(
+            "PLANE_MCP_MODULES contains unknown module(s): %s. "
+            "Valid modules: %s",
+            ", ".join(sorted(unknown)),
+            ", ".join(sorted(_ALL_MODULES.keys())),
+        )
+    return enabled
+
 
 def register_tools(mcp: FastMCP) -> None:
-    """Register all tools with the MCP server."""
-    register_project_tools(mcp)
-    register_work_item_tools(mcp)
-    register_work_item_activity_tools(mcp)
-    register_work_item_comment_tools(mcp)
-    register_work_item_link_tools(mcp)
-    register_work_item_relation_tools(mcp)
-    register_work_log_tools(mcp)
-    register_cycle_tools(mcp)
-    register_user_tools(mcp)
-    register_module_tools(mcp)
-    register_initiative_tools(mcp)
-    register_intake_tools(mcp)
-    register_label_tools(mcp)
-    register_page_tools(mcp)
-    register_work_item_property_tools(mcp)
-    register_work_item_type_tools(mcp)
-    register_state_tools(mcp)
-    register_workspace_tools(mcp)
-    register_epic_tools(mcp)
-    register_milestone_tools(mcp)
+    """Register tools with the MCP server based on PLANE_MCP_MODULES env var.
+
+    Set PLANE_MCP_MODULES to a comma-separated list of module names to load
+    only those modules. Use 'all' (or leave unset) to load everything.
+
+    Available modules:
+        projects, work_items, work_item_activities, work_item_comments,
+        work_item_links, work_item_relations, work_item_types,
+        work_item_properties, work_logs, cycles, modules, epics, milestones,
+        initiatives, intake, labels, pages, states, users, workspaces
+
+    Example:
+        PLANE_MCP_MODULES=projects,work_items,states,labels,users,workspaces,epics
+    """
+    enabled = _get_enabled_modules()
+
+    total_tools = 0
+    loaded_modules = []
+
+    for module_name, (register_fn, tool_count) in _ALL_MODULES.items():
+        if enabled is None or module_name in enabled:
+            register_fn(mcp)
+            loaded_modules.append(module_name)
+            total_tools += tool_count
+
+    logger.info(
+        "Plane MCP: loaded %d module(s) with ~%d tool(s). "
+        "Set PLANE_MCP_MODULES to restrict modules. Loaded: %s",
+        len(loaded_modules),
+        total_tools,
+        ", ".join(loaded_modules),
+    )


### PR DESCRIPTION
## Summary

Adds a `PLANE_MCP_MODULES` environment variable that lets operators control which tool modules are registered with the MCP server at startup — reducing the total number of exposed tools from **109 to a configurable subset**.

This is useful when:
- An MCP client has a hard limit on the number of tools it accepts
- You want to keep the AI's context focused on a specific domain
- You're running a minimal/lightweight deployment

## How it works

| Value | Behaviour |
|-------|-----------|
| `all` (default, or unset) | All 109 tools loaded — fully backward-compatible |
| `projects,work_items,...` | Only the listed modules are registered |
| Unknown module name | Warning is logged, valid modules still load |

**Minimal example** (~35 tools):
```json
{
  "mcpServers": {
    "plane": {
      "command": "uvx",
      "args": ["plane-mcp-server", "stdio"],
      "env": {
        "PLANE_API_KEY": "...",
        "PLANE_WORKSPACE_SLUG": "...",
        "PLANE_MCP_MODULES": "projects,work_items,states,labels,users,workspaces,epics"
      }
    }
  }
}
```

## Changes

### `plane_mcp/tools/__init__.py`
- Introduces `_ALL_MODULES` — a dict registry mapping module names to their `register_*` functions and tool counts
- Adds `_get_enabled_modules()` to parse the env variable with validation and warning for unknown names
- Refactors `register_tools()` to iterate over the registry and conditionally register each module
- Adds startup log showing how many modules/tools were loaded

### `README.md`
- New *Restricting Loaded Tools* section under Configuration
- Module reference table with tool counts and descriptions
- Minimal-set stdio config example

### `.env.test`
- Documents `PLANE_MCP_MODULES` with available module names and example values

## Backward Compatibility

✅ No breaking changes. When `PLANE_MCP_MODULES` is not set (or set to `all`), behaviour is identical to before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable environment variable to selectively restrict which MCP tool modules are loaded, allowing users to optimize performance by enabling only required modules.

* **Documentation**
  * Documented the new configuration option with complete module listings, tool counts, and practical configuration examples for the MCP server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->