### PR TITLE
feat: add advanced_search_work_items tool

### DIFF
--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -6,6 +6,8 @@ from fastmcp import FastMCP
 from plane.models.enums import PriorityEnum
 from plane.models.query_params import RetrieveQueryParams, WorkItemQueryParams
 from plane.models.work_items import (
+    AdvancedSearchResult,
+    AdvancedSearchWorkItem,
     CreateWorkItem,
     PaginatedWorkItemResponse,
     UpdateWorkItem,
@@ -374,3 +376,52 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         )
 
         return client.work_items.search(workspace_slug=workspace_slug, query=query, params=params)
+
+    @mcp.tool()
+    def advanced_search_work_items(
+        query: str | None = None,
+        filters: dict | None = None,
+        project_id: str | None = None,
+        workspace_search: bool | None = None,
+        limit: int | None = None,
+    ) -> list[AdvancedSearchResult]:
+        """
+        Search work items with advanced filters using AND/OR logic.
+
+        Supports filtering by assignee, state, priority, labels, dates, and more
+        using structured filter groups. Use this when you need to find work items
+        matching specific criteria (e.g. unassigned urgent items, items in a
+        particular state group).
+
+        Filter keys include: assignee_id, assignee_id__in, state_id, state_id__in,
+        state_group, state_group__in, priority, priority__in, label_id, label_id__in,
+        created_by_id, created_by_id__in, is_draft, is_archived, start_date, target_date,
+        target_date__range, cycle_id, module_id, subscriber_id, and more.
+
+        Args:
+            query: Optional free-text search string to match against work item
+                   name and description
+            filters: Optional structured filter dict using AND/OR groups.
+                     Example: {"and": [{"state_group__in": ["unstarted", "started"]},
+                     {"priority__in": ["urgent", "high"]}]}
+            project_id: Optional project UUID to scope the search to a single project
+            workspace_search: If true, search across all projects in the workspace
+            limit: Maximum number of results to return
+
+        Returns:
+            List of AdvancedSearchResult objects
+        """
+        client, workspace_slug = get_plane_client_context()
+
+        data = AdvancedSearchWorkItem(
+            query=query,
+            filters=filters,
+            limit=limit,
+            project_id=project_id,
+            workspace_search=workspace_search,
+        )
+
+        return client.work_items.advanced_search(
+            workspace_slug=workspace_slug,
+            data=data,
+        )


### PR DESCRIPTION
## Summary

Adds a new `advanced_search_work_items` MCP tool that exposes the advanced search endpoint, enabling structured filtering of work items by assignee, state, priority, labels, dates, and more using AND/OR logic.

## New Tool: `advanced_search_work_items`

Parameters:
- `query` — optional free-text search
- `filters` — structured AND/OR filter dict (e.g. `{"and": [{"state_group__in": ["unstarted", "started"]}, {"priority__in": ["urgent", "high"]}]}`)
- `project_id` — scope to a specific project
- `workspace_search` — search across all projects
- `limit` — max results

Supported filter keys: `assignee_id`, `state_id`, `state_group`, `priority`, `label_id`, `created_by_id`, `is_draft`, `is_archived`, `start_date`, `target_date`, `cycle_id`, `module_id`, `subscriber_id`, and their `__in` variants.

## Context

This complements the existing `search_work_items` tool (text search only) with full filter support via the existing `advanced-search` API endpoint.

## Dependency

- Requires [plane-python-sdk#24](https://github.com/makeplane/plane-python-sdk/pull/24) for `project_id` and `workspace_search` support in `AdvancedSearchWorkItem`

## Verified
- All 13 non-integration tests pass
- Advanced search filtering tested end-to-end against UAT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an advanced work-item search: free-text query plus structured AND/OR filters, optional project scoping or workspace-wide search, and result limiting for more precise, targeted searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->