### PR TITLE
fix: validate API key in PlaneHeaderAuthProvider and pin fakeredis<2.35.0

### DIFF
--- a/plane_mcp/auth/plane_header_auth_provider.py
+++ b/plane_mcp/auth/plane_header_auth_provider.py
@@ -28,7 +28,7 @@ class PlaneHeaderAuthProvider(TokenVerifier):
                 response = await client.get(
                     user_url,
                     headers={
-                        "Authorization": f"Bearer {token}",
+                        "x-api-key": token,
                         "Content-Type": "application/json",
                     },
                 )

--- a/plane_mcp/auth/plane_header_auth_provider.py
+++ b/plane_mcp/auth/plane_header_auth_provider.py
@@ -1,15 +1,44 @@
+import os
 import time
 
+import httpx
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_PLANE_BASE_URL = "https://api.plane.so"
+
 
 class PlaneHeaderAuthProvider(TokenVerifier):
-    def __init__(self, required_scopes: list[str] | None = None):
+    def __init__(self, required_scopes: list[str] | None = None, timeout_seconds: int = 10):
         super().__init__(required_scopes=required_scopes)
+        self.timeout_seconds = timeout_seconds
+
+    async def _validate_api_key(self, token: str) -> bool:
+        """Validate the API key by calling the Plane API."""
+        base_url = (os.getenv("PLANE_INTERNAL_BASE_URL") or os.getenv("PLANE_BASE_URL", DEFAULT_PLANE_BASE_URL)).rstrip(
+            "/"
+        )
+        user_url = f"{base_url}/api/v1/users/me/"
+
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                response = await client.get(
+                    user_url,
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                )
+                if response.status_code != 200:
+                    logger.warning("API key validation failed: %s", response.status_code)
+                    return False
+                return True
+        except httpx.RequestError as e:
+            logger.warning("API key validation request failed: %s", e)
+            return False
 
     async def verify_token(self, token: str) -> AccessToken | None:
         try:
@@ -19,21 +48,26 @@ class PlaneHeaderAuthProvider(TokenVerifier):
 
             if token:
                 workspace_slug = headers.get("x-workspace-slug")
-                if workspace_slug:
-                    logger.info("Using API key from HTTP headers")
-                    expires_at = int(time.time() + 3600)
-                    return AccessToken(
-                        token=token,
-                        client_id="api_key_header_user",
-                        scopes=["read", "write"],
-                        expires_at=expires_at,
-                        claims={
-                            "auth_method": "api_key_header",
-                            "workspace_slug": workspace_slug,
-                        },
-                    )
-                else:
+                if not workspace_slug:
                     logger.warning("x-api-key header found but x-workspace-slug is missing")
+                    return None
+
+                if not await self._validate_api_key(token):
+                    logger.warning("API key validation against Plane API failed")
+                    return None
+
+                logger.info("API key validated successfully via Plane API")
+                expires_at = int(time.time() + 3600)
+                return AccessToken(
+                    token=token,
+                    client_id="api_key_header_user",
+                    scopes=["read", "write"],
+                    expires_at=expires_at,
+                    claims={
+                        "auth_method": "api_key_header",
+                        "workspace_slug": workspace_slug,
+                    },
+                )
         except RuntimeError:
             # No active HTTP request available (e.g., stdio transport)
             logger.debug("No active HTTP request available for header check")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plane-mcp-server"
-version = "0.2.8"
+version = "0.2.9"
 description = "A Model Context Protocol server for Plane integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
     "mcp==1.26.0",
     "PyJWT>=2.12.0",
     "authlib>=1.6.9",
+    # pydocket 0.16.6 (pinned by fastmcp 2.14.4) imports `FakeConnection` from
+    # `fakeredis.aioredis`, which was removed in fakeredis 2.35.0.
+    "fakeredis[lua]>=2.32.1,<2.35.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -916,7 +916,7 @@ wheels = [
 
 [[package]]
 name = "plane-mcp-server"
-version = "0.2.8"
+version = "0.2.9"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -920,6 +920,7 @@ version = "0.2.8"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "fakeredis", extra = ["lua"] },
     { name = "fastmcp" },
     { name = "mcp" },
     { name = "plane-sdk" },
@@ -936,6 +937,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "authlib", specifier = ">=1.6.9" },
+    { name = "fakeredis", extras = ["lua"], specifier = ">=2.32.1,<2.35.0" },
     { name = "fastmcp", specifier = "==2.14.4" },
     { name = "mcp", specifier = "==1.26.0" },
     { name = "plane-sdk", specifier = "==0.2.8" },


### PR DESCRIPTION
## Summary

- **Auth bypass fix:** `PlaneHeaderAuthProvider.verify_token` previously accepted any non-empty string as a valid API key. It now validates the key against the Plane API (`GET /api/v1/users/me/` with the `x-api-key` header) before issuing an `AccessToken`. This matches the validation pattern used by `PlaneOAuthTokenVerifier`.
- **Startup crash fix:** Pinned `fakeredis[lua]>=2.32.1,<2.35.0`. `pydocket 0.16.6` (transitively pinned by `fastmcp==2.14.4`) imports `FakeConnection` from `fakeredis.aioredis`, which was removed in fakeredis 2.35.0, causing `ImportError` on server startup.

## Changes

- `plane_mcp/auth/plane_header_auth_provider.py` — added `_validate_api_key()` that hits the Plane API; `verify_token` now returns `None` when the key is invalid or the workspace slug header is missing.
- `pyproject.toml` / `uv.lock` — added `fakeredis[lua]>=2.32.1,<2.35.0` constraint (resolves to 2.33.0).

## Test plan

- [x] Built the Docker image and started the container locally — no `ImportError`, server boots cleanly on :8211.
- [x] Verify a request with a bogus `x-api-key` header is rejected (was previously accepted).
- [x] Verify a request with a valid `x-api-key` + `x-workspace-slug` still authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key validation now supports a configurable timeout (default: 10s)

* **Bug Fixes**
  * Token verification strengthened to require both authentication headers
  * Failed validation now returns consistent negative results and clearer logging

* **Chores**
  * Project version bumped and dependency list updated to include a constrained caching package
<!-- end of auto-generated comment: release notes by coderabbit.ai -->