### PR TITLE
[SILO-1181] feat: support configurable subpath prefix for MCP server

### DIFF
--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -87,13 +87,19 @@ def main() -> None:
         return
 
     if server_mode == ServerMode.HTTP:
-        oauth_mcp = get_oauth_mcp("/http")
+
+        prefix = os.getenv("MCP_PATH_PREFIX") or ""
+
+        oauth_mcp = get_oauth_mcp(prefix + "/http")
         oauth_app = oauth_mcp.http_app(stateless_http=True)
         header_app = get_header_mcp().http_app(stateless_http=True)
 
-        sse_mcp = get_oauth_mcp()
+        sse_mcp = get_oauth_mcp(prefix)
         sse_app = sse_mcp.http_app(transport="sse")
 
+        # mcp_path is appended to the auth provider's base_url to form the
+        # advertised resource URL. base_url already carries the prefix, so these
+        # stay at /mcp and /sse to avoid double-prefixing.
         oauth_well_known = oauth_mcp.auth.get_well_known_routes(mcp_path="/mcp")
         sse_well_known = sse_mcp.auth.get_well_known_routes(mcp_path="/sse")
 
@@ -103,9 +109,9 @@ def main() -> None:
                 *oauth_well_known,
                 *sse_well_known,
                 # Mount both MCP servers
-                Mount("/http/api-key", app=header_app),
-                Mount("/http", app=oauth_app),
-                Mount("/", app=sse_app),
+                Mount(prefix + "/http/api-key", app=header_app),
+                Mount(prefix + "/http", app=oauth_app),
+                Mount(prefix or "/", app=sse_app),
             ],
             lifespan=lambda app: combined_lifespan(oauth_app, header_app, sse_app),
         )

--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -320,8 +320,8 @@ class PlaneOAuthProvider(OAuthProxy):
         plane_base_url_final = settings.plane_base_url or os.getenv("PLANE_BASE_URL", DEFAULT_PLANE_BASE_URL)
         # Internal URL for server-to-server calls (token exchange, API verification)
         # Falls back to external URL if not set
-        plane_internal_url = settings.plane_internal_base_url or os.getenv(
-            "PLANE_INTERNAL_BASE_URL", plane_base_url_final
+        plane_internal_url = (
+            settings.plane_internal_base_url or os.getenv("PLANE_INTERNAL_BASE_URL") or plane_base_url_final
         )
 
         # Create Plane token verifier (uses internal URL for server-to-server calls)


### PR DESCRIPTION
## Summary

- Adds an optional `MCP_PATH_PREFIX` env var so the HTTP server can be deployed behind an ingress that serves it under a subpath (e.g. `/mcp`).
- All three transports — OAuth streamable-http (`/http/mcp`), header-auth streamable-http (`/http/api-key/mcp`), and SSE (`/sse`) — are now mounted under the prefix.
- Each OAuth provider's `base_url` is built with the prefix so advertised metadata (issuer, authorize, token, register, and protected-resource URLs) resolves to the externally-visible path.
- `mcp_path` for well-known routes stays at `/mcp` and `/sse` (relative to `base_url`) to avoid double-prefixing the advertised resource URL.
- When `MCP_PATH_PREFIX` is unset, routing and metadata are identical to before — no behavior change for existing deployments.

Tracks: SILO-1181.

## Test plan

- [x] Start locally with `MCP_PATH_PREFIX=/mcp`, `PLANE_OAUTH_PROVIDER_BASE_URL=http://localhost:8211` (no prefix in env var).
- [x] Verify `GET /.well-known/oauth-authorization-server/mcp/http` returns issuer `http://localhost:8211/mcp/http` and registration endpoint `http://localhost:8211/mcp/http/register`.
- [x] Verify `GET /.well-known/oauth-authorization-server/mcp` (SSE) returns issuer `http://localhost:8211/mcp`.
- [x] Verify `GET /.well-known/oauth-protected-resource/mcp/http/mcp` advertises resource `http://localhost:8211/mcp/http/mcp`.
- [x] `POST /mcp/http/mcp` returns 401 (OAuth challenge) — not 404.
- [ ] `POST /mcp/http/api-key/mcp` with valid `x-workspace-slug` + `authorization` headers initializes successfully.
- [ ] `GET /mcp/sse` returns 401 (not 404).
- [ ] End-to-end OAuth flow via `test_client.py::test_oauth_mcp` against `http://localhost:8211/mcp/http/mcp` completes successfully.
- [ ] Without `MCP_PATH_PREFIX` set, existing URLs (`/http/mcp`, `/http/api-key/mcp`, `/sse`) continue to work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an environment variable to set an API path prefix, allowing OAuth and realtime (SSE) endpoints to be mounted under custom paths.
* **Bug Fixes**
  * Improved mount behavior to avoid empty-path issues for realtime connections.
  * Improved server-to-server endpoint selection to better handle varied deployment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane-mcp-server/pull/106)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->