### PR TITLE
Update command args with headers in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Connect to the hosted Plane MCP server using OAuth authentication.
 
 Connect to the hosted Plane MCP server using a Personal Access Token (PAT).
 
-**URL**: `https://mcp.plane.so/api-key/mcp`
+**URL**: `https://mcp.plane.so/http/api-key/mcp`
 
 **Headers**:
 - `Authorization: Bearer <PAT_TOKEN>`

--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ Connect to the hosted Plane MCP server using a Personal Access Token (PAT).
   "mcpServers": {
     "plane": {
       "command": "npx",
-      "args": ["mcp-remote@latest", "https://mcp.plane.so/http/api-key/mcp"],
-      "headers": {
-        "Authorization": "Bearer <PAT_TOKEN>",
-        "X-Workspace-slug": "<SLUG>"
-      }
+      "args": [
+        "mcp-remote@latest",
+        "https://mcp.plane.so/http/api-key/mcp",
+        "--header",
+        "Authorization: Bearer <PAT_TOKEN>",
+        "--header",
+        "X-Workspace-slug: <SLUG>"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description
Because mcp-remote does not support separate headers object. It expects them as arguments.

### Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [X] Documentation update

### Screenshots and Media (if applicable)
https://www.npmjs.com/package/mcp-remote

### Test Scenarios 
Successfully tested with claude desktop app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the PAT-token remote HTTP MCP client configuration example to use CLI arguments for specifying authentication and workspace headers instead of a top-level configuration object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->