### PR TITLE
feat: add tools for reading work item property values

### DIFF
--- a/plane_mcp/tools/work_item_properties.py
+++ b/plane_mcp/tools/work_item_properties.py
@@ -11,6 +11,7 @@ from plane.models.work_item_properties import (
     PropertySettings,
     UpdateWorkItemProperty,
     WorkItemProperty,
+    WorkItemPropertyValueDetail,
 )
 from plane.models.work_item_property_configurations import (
     DateAttributeSettings,
@@ -280,38 +281,31 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
     def list_work_item_property_values(
         project_id: str,
         work_item_id: str,
-        include_unset: bool = False,
-    ) -> list[dict[str, Any]]:
+    ) -> list[WorkItemPropertyValueDetail]:
         """
         List custom property values currently set on a work item.
 
-        Resolves the work item's type, lists all active property definitions for
-        that type, and fetches the value (if any) for each property. Useful for
-        retrieving member-type custom fields such as ``Responsible`` or ``Review``
-        whose values do not appear in ``retrieve_work_item``.
+        Resolves the work item's type, iterates over all active property
+        definitions for that type, and fetches the value (if any) for each
+        property. Useful for retrieving member-type custom fields such as
+        ``Responsible`` or ``Review`` whose values do not appear in
+        ``retrieve_work_item`` under any value of ``expand``.
 
         Args:
             project_id: UUID of the project
             work_item_id: UUID of the work item
-            include_unset: If True, include properties without a set value
-                (``value`` will be ``None``). Default False — only properties
-                with values are returned.
 
         Returns:
-            List of dicts, one per property. Each dict contains:
-              - ``property_id``: UUID of the property definition
-              - ``display_name``: Human-readable name (e.g. "Responsible")
-              - ``name``: Internal name (slug)
-              - ``property_type``: TEXT/DATETIME/DECIMAL/BOOLEAN/OPTION/RELATION/URL/EMAIL/FILE
-              - ``relation_type``: USER/ISSUE for RELATION properties, else None
-              - ``is_multi``: Whether the property accepts multiple values
-              - ``value``: Single value or list of values (for multi). For
-                RELATION/USER it is the user UUID(s).
-              - ``value_record_ids``: ID(s) of the underlying value records.
+            Flat list of ``WorkItemPropertyValueDetail`` objects, one per
+            single-value property that has a value set; multi-value properties
+            contribute one entry per value. Properties without a value, or
+            marked ``is_active=False``, are omitted. Returns an empty list if
+            the work item has no type assigned.
 
-        Notes:
-            * Returns an empty list if the work item has no type assigned.
-            * Properties marked ``is_active=False`` are skipped.
+            Each entry exposes ``property_id``, so callers that need the
+            human-readable name should pair this with
+            ``list_work_item_properties(project_id, type_id)`` to map IDs to
+            ``display_name``.
         """
         client, workspace_slug = get_plane_client_context()
 
@@ -330,13 +324,10 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
             type_id=type_id,
         )
 
-        result: list[dict[str, Any]] = []
+        result: list[WorkItemPropertyValueDetail] = []
         for prop in properties:
             if not getattr(prop, "is_active", True):
                 continue
-
-            value: Any = None
-            value_record_ids: Any = None
             try:
                 value_obj = client.work_item_properties.values.retrieve(
                     workspace_slug=workspace_slug,
@@ -345,32 +336,21 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
                     property_id=prop.id,
                 )
             except HttpError as exc:
-                if exc.status_code != 404:
-                    raise
-                value_obj = None
-
-            if value_obj is None:
-                if not include_unset:
+                # Invariant: ``work_item_id`` was just resolved successfully and
+                # ``prop.id`` comes from the authoritative type-bound property
+                # listing — neither can be invalid here. The Plane API returns
+                # 404 with ``{"error": "Property value not set for this work
+                # item"}`` for properties that simply have no value, so a 404
+                # at this point means "unset" and we skip it. Any other status
+                # is a real error and is propagated.
+                if exc.status_code == 404:
                     continue
-            elif isinstance(value_obj, list):
-                value = [item.value for item in value_obj]
-                value_record_ids = [item.id for item in value_obj]
-            else:
-                value = value_obj.value
-                value_record_ids = value_obj.id
+                raise
 
-            result.append(
-                {
-                    "property_id": prop.id,
-                    "display_name": prop.display_name,
-                    "name": getattr(prop, "name", None),
-                    "property_type": _enum_value(prop.property_type),
-                    "relation_type": _enum_value(prop.relation_type),
-                    "is_multi": bool(getattr(prop, "is_multi", False)),
-                    "value": value,
-                    "value_record_ids": value_record_ids,
-                }
-            )
+            if isinstance(value_obj, list):
+                result.extend(value_obj)
+            else:
+                result.append(value_obj)
 
         return result
 
@@ -379,7 +359,7 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
         project_id: str,
         work_item_id: str,
         property_id: str,
-    ) -> dict[str, Any] | list[dict[str, Any]] | None:
+    ) -> WorkItemPropertyValueDetail | list[WorkItemPropertyValueDetail]:
         """
         Retrieve the value(s) of a single custom property for a work item.
 
@@ -389,32 +369,23 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
             property_id: UUID of the property definition
 
         Returns:
-            For single-value properties: a dict (or ``None`` if the value is
-            not set). For multi-value properties: a list of dicts.
-            Each dict mirrors ``WorkItemPropertyValueDetail`` (id, value,
-            value_type, property_id, issue_id, created_at, updated_at, ...).
+            ``WorkItemPropertyValueDetail`` for single-value properties or a
+            list of ``WorkItemPropertyValueDetail`` for multi-value properties
+            (``is_multi=True``).
+
+        Raises:
+            HttpError: ``status_code=404`` is raised both when the
+                ``work_item_id`` / ``property_id`` is invalid *and* when the
+                property has no value set; the underlying Plane API does not
+                distinguish between the two cases at this endpoint. Use
+                ``list_work_item_property_values`` to enumerate properties that
+                are currently set on a work item without having to handle 404s.
         """
         client, workspace_slug = get_plane_client_context()
 
-        try:
-            value_obj = client.work_item_properties.values.retrieve(
-                workspace_slug=workspace_slug,
-                project_id=project_id,
-                work_item_id=work_item_id,
-                property_id=property_id,
-            )
-        except HttpError as exc:
-            if exc.status_code == 404:
-                return None
-            raise
-
-        if isinstance(value_obj, list):
-            return [item.model_dump() for item in value_obj]
-        return value_obj.model_dump()
-
-
-def _enum_value(value: Any) -> Any:
-    """Convert an enum-like field to its plain value, leave other types alone."""
-    if value is None:
-        return None
-    return getattr(value, "value", value)
+        return client.work_item_properties.values.retrieve(
+            workspace_slug=workspace_slug,
+            project_id=project_id,
+            work_item_id=work_item_id,
+            property_id=property_id,
+        )

--- a/plane_mcp/tools/work_item_properties.py
+++ b/plane_mcp/tools/work_item_properties.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from fastmcp import FastMCP
+from plane.errors import HttpError
 from plane.models.enums import PropertyType, RelationType
 from plane.models.work_item_properties import (
     CreateWorkItemProperty,
@@ -274,3 +275,146 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
             type_id=type_id,
             work_item_property_id=work_item_property_id,
         )
+
+    @mcp.tool()
+    def list_work_item_property_values(
+        project_id: str,
+        work_item_id: str,
+        include_unset: bool = False,
+    ) -> list[dict[str, Any]]:
+        """
+        List custom property values currently set on a work item.
+
+        Resolves the work item's type, lists all active property definitions for
+        that type, and fetches the value (if any) for each property. Useful for
+        retrieving member-type custom fields such as ``Responsible`` or ``Review``
+        whose values do not appear in ``retrieve_work_item``.
+
+        Args:
+            project_id: UUID of the project
+            work_item_id: UUID of the work item
+            include_unset: If True, include properties without a set value
+                (``value`` will be ``None``). Default False — only properties
+                with values are returned.
+
+        Returns:
+            List of dicts, one per property. Each dict contains:
+              - ``property_id``: UUID of the property definition
+              - ``display_name``: Human-readable name (e.g. "Responsible")
+              - ``name``: Internal name (slug)
+              - ``property_type``: TEXT/DATETIME/DECIMAL/BOOLEAN/OPTION/RELATION/URL/EMAIL/FILE
+              - ``relation_type``: USER/ISSUE for RELATION properties, else None
+              - ``is_multi``: Whether the property accepts multiple values
+              - ``value``: Single value or list of values (for multi). For
+                RELATION/USER it is the user UUID(s).
+              - ``value_record_ids``: ID(s) of the underlying value records.
+
+        Notes:
+            * Returns an empty list if the work item has no type assigned.
+            * Properties marked ``is_active=False`` are skipped.
+        """
+        client, workspace_slug = get_plane_client_context()
+
+        work_item = client.work_items.retrieve(
+            workspace_slug=workspace_slug,
+            project_id=project_id,
+            work_item_id=work_item_id,
+        )
+        type_id = getattr(work_item, "type_id", None)
+        if not type_id:
+            return []
+
+        properties = client.work_item_properties.list(
+            workspace_slug=workspace_slug,
+            project_id=project_id,
+            type_id=type_id,
+        )
+
+        result: list[dict[str, Any]] = []
+        for prop in properties:
+            if not getattr(prop, "is_active", True):
+                continue
+
+            value: Any = None
+            value_record_ids: Any = None
+            try:
+                value_obj = client.work_item_properties.values.retrieve(
+                    workspace_slug=workspace_slug,
+                    project_id=project_id,
+                    work_item_id=work_item_id,
+                    property_id=prop.id,
+                )
+            except HttpError as exc:
+                if exc.status_code != 404:
+                    raise
+                value_obj = None
+
+            if value_obj is None:
+                if not include_unset:
+                    continue
+            elif isinstance(value_obj, list):
+                value = [item.value for item in value_obj]
+                value_record_ids = [item.id for item in value_obj]
+            else:
+                value = value_obj.value
+                value_record_ids = value_obj.id
+
+            result.append(
+                {
+                    "property_id": prop.id,
+                    "display_name": prop.display_name,
+                    "name": getattr(prop, "name", None),
+                    "property_type": _enum_value(prop.property_type),
+                    "relation_type": _enum_value(prop.relation_type),
+                    "is_multi": bool(getattr(prop, "is_multi", False)),
+                    "value": value,
+                    "value_record_ids": value_record_ids,
+                }
+            )
+
+        return result
+
+    @mcp.tool()
+    def retrieve_work_item_property_value(
+        project_id: str,
+        work_item_id: str,
+        property_id: str,
+    ) -> dict[str, Any] | list[dict[str, Any]] | None:
+        """
+        Retrieve the value(s) of a single custom property for a work item.
+
+        Args:
+            project_id: UUID of the project
+            work_item_id: UUID of the work item
+            property_id: UUID of the property definition
+
+        Returns:
+            For single-value properties: a dict (or ``None`` if the value is
+            not set). For multi-value properties: a list of dicts.
+            Each dict mirrors ``WorkItemPropertyValueDetail`` (id, value,
+            value_type, property_id, issue_id, created_at, updated_at, ...).
+        """
+        client, workspace_slug = get_plane_client_context()
+
+        try:
+            value_obj = client.work_item_properties.values.retrieve(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                work_item_id=work_item_id,
+                property_id=property_id,
+            )
+        except HttpError as exc:
+            if exc.status_code == 404:
+                return None
+            raise
+
+        if isinstance(value_obj, list):
+            return [item.model_dump() for item in value_obj]
+        return value_obj.model_dump()
+
+
+def _enum_value(value: Any) -> Any:
+    """Convert an enum-like field to its plain value, leave other types alone."""
+    if value is None:
+        return None
+    return getattr(value, "value", value)


### PR DESCRIPTION
## Summary

Add two read-only MCP tools that expose work item **custom property values** (e.g. `Responsible`, `Review`, or any other RELATION/OPTION/TEXT… property). Both tools wrap the existing `client.work_item_properties.values` resource that already lives in `plane-sdk` but was previously not exposed through MCP.

- `list_work_item_property_values(project_id, work_item_id, include_unset=False)` — high-level helper. Resolves the work item's `type_id` internally, lists all active property definitions for that type, and returns a flat list of `{property_id, display_name, name, property_type, relation_type, is_multi, value, value_record_ids}`. By default only properties with a set value are returned; pass `include_unset=True` to also list active properties without values.
- `retrieve_work_item_property_value(project_id, work_item_id, property_id)` — granular retrieve. Returns a dict mirroring `WorkItemPropertyValueDetail` for single-value properties, a list of dicts for multi-value properties, and `None` if the value is not set (Plane returns `404 \"Property value not set\"` in that case, and we trap it).

No write tools (`set` / `delete`) are added in this PR — kept intentionally minimal.

## Motivation

Member-type custom fields (RELATION/USER) are not returned by `retrieve_work_item` under any value of `expand` (`property_values`, `properties`, `issue_properties`, `custom_properties` were all tried — none populate the field on the response). Until now, MCP clients had no way to read these properties at all, even though the underlying Plane API and the SDK already support it (`/work-items/{id}/work-item-properties/{property_id}/values/`).

## Implementation notes

The tools return plain `dict[str, Any]` rather than the SDK Pydantic models. This is intentional and avoids inheriting the FastMCP output-validation issue described in #78: `WorkItemProperty` declares `display_name: str` and `property_type: PropertyType` as required, but the backend can legitimately return `null` in adjacent fields (`description`, `external_source`, `external_id`, …), which makes FastMCP's auto-generated JSON Schema reject otherwise-valid responses with `Output validation error: None is not of type 'string'`. By returning hand-built dicts, the new tools sidestep that path entirely.

Related: #78 (same root cause; this PR does not fix it but demonstrates a workaround that future PRs can apply more broadly).

## Test plan

- [x] `python -m py_compile` and `ruff check` clean on the modified file.
- [x] Smoke-imported the package and registered the new tools through a fake MCP context.
- [x] Verified against a self-hosted Plane (v1.3.0) workspace:
  - `list_work_item_property_values` returns the correct UUIDs for `Responsible` and `Review` (RELATION/USER properties on a work item that has them set).
  - `include_unset=True` adds an entry for an unset OPTION property with `value: null`.
  - `retrieve_work_item_property_value` returns the expected `WorkItemPropertyValueDetail` payload for a property with a value, and `None` for a property without one (404 from the API is trapped).
- [x] Confirmed the tools are visible alongside the existing `*_work_item_property` CRUD tools after `register_work_item_property_tools(mcp)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to list all custom property values for a work item, with optional support for including unset properties
  * Added ability to retrieve the value for a specific work item property
  * Enhanced property data formatting and normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->