### PR TITLE
fix: return success from module work item add tool

### DIFF
--- a/plane_mcp/tools/modules.py
+++ b/plane_mcp/tools/modules.py
@@ -1,6 +1,6 @@
 """Module-related tools for Plane MCP Server."""
 
-from typing import Any, get_args
+from typing import Any, TypedDict, get_args
 
 from fastmcp import FastMCP
 from plane.models.enums import ModuleStatusEnum
@@ -15,6 +15,12 @@ from plane.models.modules import (
 from plane.models.work_items import WorkItem
 
 from plane_mcp.client import get_plane_client_context
+
+
+class AddWorkItemsToModuleResult(TypedDict):
+    """Result returned after successfully adding work items to a module."""
+
+    success: bool
 
 
 def register_module_tools(mcp: FastMCP) -> None:
@@ -208,7 +214,7 @@ def register_module_tools(mcp: FastMCP) -> None:
         project_id: str,
         module_id: str,
         work_item_ids: list[str],
-    ) -> None:
+    ) -> AddWorkItemsToModuleResult:
         """
         Add work items to a module.
 
@@ -216,6 +222,9 @@ def register_module_tools(mcp: FastMCP) -> None:
             project_id: UUID of the project
             module_id: UUID of the module
             work_item_ids: List of work item UUIDs to add to the module
+
+        Returns:
+            Success status for the operation
         """
         client, workspace_slug = get_plane_client_context()
         client.modules.add_work_items(
@@ -224,6 +233,7 @@ def register_module_tools(mcp: FastMCP) -> None:
             module_id=module_id,
             issue_ids=work_item_ids,
         )
+        return {"success": True}
 
     @mcp.tool()
     def remove_work_item_from_module(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -44,7 +44,7 @@ def extract_result(result):
         if hasattr(content, "text"):
             try:
                 return json.loads(content.text)
-            except:
+            except json.JSONDecodeError:
                 return {"raw": content.text}
     return {}
 

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -1,0 +1,69 @@
+"""Tests for module tools."""
+
+import asyncio
+
+from fastmcp import Client, FastMCP
+
+from plane_mcp.tools import modules as module_tools
+
+
+class FakeModulesClient:
+    def __init__(self) -> None:
+        self.add_work_items_calls: list[dict[str, object]] = []
+
+    def add_work_items(
+        self,
+        workspace_slug: str,
+        project_id: str,
+        module_id: str,
+        issue_ids: list[str],
+    ) -> list[dict[str, str]]:
+        self.add_work_items_calls.append(
+            {
+                "workspace_slug": workspace_slug,
+                "project_id": project_id,
+                "module_id": module_id,
+                "issue_ids": issue_ids,
+            }
+        )
+        return [{"id": "module-issue-id", "module": module_id, "issue": issue_ids[0]}]
+
+
+class FakePlaneClient:
+    def __init__(self) -> None:
+        self.modules = FakeModulesClient()
+
+
+def test_add_work_items_to_module_returns_success_payload(monkeypatch) -> None:
+    """A successful SDK list response should not leak into MCP response validation."""
+    fake_client = FakePlaneClient()
+    monkeypatch.setattr(
+        module_tools,
+        "get_plane_client_context",
+        lambda: (fake_client, "test-workspace"),
+    )
+
+    async def call_tool() -> object:
+        mcp = FastMCP("test")
+        module_tools.register_module_tools(mcp)
+
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "add_work_items_to_module",
+                {
+                    "project_id": "project-id",
+                    "module_id": "module-id",
+                    "work_item_ids": ["work-item-id"],
+                },
+            )
+            return result.structured_content
+
+    assert asyncio.run(call_tool()) == {"success": True}
+    assert fake_client.modules.add_work_items_calls == [
+        {
+            "workspace_slug": "test-workspace",
+            "project_id": "project-id",
+            "module_id": "module-id",
+            "issue_ids": ["work-item-id"],
+        }
+    ]

--- a/tests/test_oauth_security.py
+++ b/tests/test_oauth_security.py
@@ -22,7 +22,6 @@ from starlette.testclient import TestClient
 
 from plane_mcp.auth import PlaneOAuthProvider
 
-
 # Exact allowed patterns from plane_mcp/server.py
 ALLOWED_REDIRECT_URI_PATTERNS = [
     "http://localhost:*",

--- a/tests/test_stateless_http.py
+++ b/tests/test_stateless_http.py
@@ -12,7 +12,6 @@ from starlette.testclient import TestClient
 
 from plane_mcp.auth import PlaneHeaderAuthProvider, PlaneOAuthProvider
 
-
 ALLOWED_REDIRECT_URI_PATTERNS = [
     "http://localhost:*",
     "http://localhost:*/*",


### PR DESCRIPTION
### Description
Fixes `add_work_items_to_module` returning `Unexpected response type` even after the Plane API successfully adds the work item to the module.

The module work-item endpoint returns a JSON array of association records. Since the MCP tool was typed as returning `None`, that successful SDK response could still conflict with MCP response handling.

This PR changes `add_work_items_to_module` to return a structured success response after the SDK call completes, and adds a regression test covering the SDK returning a list.

It also fixes a few existing Ruff issues in tests so `ruff check plane_mcp tests` passes.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [ ] Documentation update

### Screenshots and Media (if applicable)
Not applicable.

### Test Scenarios 
```bash
uv run --no-sync ruff check plane_mcp tests
uv run --no-sync pytest tests/test_modules.py tests/test_stateless_http.py tests/test_oauth_security.py -q
```
Not run: live integration tests, because they require Plane credentials and a running MCP endpoint.

### References
Fixes #124.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The add work items to module operation now returns a success confirmation response.

* **Bug Fixes**
  * Improved JSON parsing error handling with more specific exception catching.

* **Tests**
  * Added comprehensive test coverage for module work item operations.

* **Chores**
  * Minor code organization improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/makeplane/plane-mcp-server/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->