### PR TITLE
chore: add support to fetch redis creds from aws secret

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -14,3 +14,32 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # PLANE_OAUTH_PROVIDER_CLIENT_ID=your_oauth_client_id
 # PLANE_OAUTH_PROVIDER_CLIENT_SECRET=your_oauth_client_secret
 # PLANE_OAUTH_PROVIDER_BASE_URL=http://localhost:8211
+
+# Optional: Route prefix — prepended to all mounted routes.
+# Use when reverse-proxying alongside other apps.
+# MCP_PATH_PREFIX=
+
+# ---------------------------------------------------------------------------
+# Redis / Token storage (HTTP / SSE modes)
+# ---------------------------------------------------------------------------
+# Without Redis, OAuth tokens are kept in memory and lost on restart.
+
+# Option A — plain Redis (no auth)
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+
+# Option B — Redis with static password (self-managed, non-rotating)
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=your_redis_password
+
+# Option C — ElastiCache with AWS Secrets Manager (rotating AUTH tokens)
+# Requires IRSA (AWS_ROLE_ARN) or EKS Pod Identity
+# (AWS_CONTAINER_CREDENTIALS_FULL_URI) — both unset = path skipped.
+# REDIS_HOST=your-cluster.cache.amazonaws.com
+# REDIS_PORT=6379
+# ELASTICACHE_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:redis-auth-XXXXXX
+# REDIS_AUTH_TOKEN_KEY=authToken   # JSON key inside the secret; default `authToken`
+# AWS_REGION=us-east-1
+# AWS_SECRET_CACHE_TTL=300         # seconds; default 300
+# REDIS_SSL=true                   # TLS — default true on this path; set `false` only for plaintext Redis

--- a/plane_mcp/aws_secrets.py
+++ b/plane_mcp/aws_secrets.py
@@ -1,0 +1,66 @@
+"""AWS Secrets Manager helpers for Redis auth token rotation.
+
+Mirrors the pattern in plane-ee/apps/api/plane/utils/aws_secrets.py — TTL-cached
+``get_secret`` keyed by (arn, region), plus a redis-py ``CredentialProvider``
+that reads the current password from the cache on every new Redis connection.
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+
+import boto3
+from redis import CredentialProvider
+
+_SECRET_CACHE: dict[tuple[str, str], dict] = {}
+_cache_lock = threading.Lock()
+_logger = logging.getLogger(__name__)
+_DEFAULT_TTL = int(os.environ.get("AWS_SECRET_CACHE_TTL", 300))
+
+
+def get_secret(secret_arn: str, region: str, force_refresh: bool = False) -> dict:
+    """Fetch and TTL-cache a secret from AWS Secrets Manager.
+
+    Returns a copy of the parsed JSON secret dict so callers cannot mutate the
+    cached value.
+    """
+    cache_key = (secret_arn, region)
+    with _cache_lock:
+        if not force_refresh and cache_key in _SECRET_CACHE:
+            entry = _SECRET_CACHE[cache_key]
+            if time.time() - entry["fetched_at"] < _DEFAULT_TTL:
+                return entry["value"].copy()
+        client = boto3.client("secretsmanager", region_name=region)
+        response = client.get_secret_value(SecretId=secret_arn)
+        value = json.loads(response["SecretString"])
+        _SECRET_CACHE[cache_key] = {"value": value, "fetched_at": time.time()}
+        _logger.info(
+            "Refreshed secret from Secrets Manager",
+            extra={"secret_arn": secret_arn},
+        )
+        return value.copy()
+
+
+class ElastiCacheCredentialProvider(CredentialProvider):
+    """redis-py credential provider that resolves the password from Secrets Manager.
+
+    ``get_credentials`` is called by redis-py during AUTH on each new connection,
+    so as long as the TTL cache returns a refreshed value after ``AWS_SECRET_CACHE_TTL``
+    seconds, rotated ElastiCache auth tokens are picked up automatically without
+    restarting the server.
+    """
+
+    def __init__(self, secret_arn: str, region: str, token_key: str, username: str | None = None):
+        self._arn = secret_arn
+        self._region = region
+        self._key = token_key
+        self._username = username
+
+    def get_credentials(self) -> tuple[str] | tuple[str, str]:
+        secret = get_secret(self._arn, self._region)
+        password = secret.get(self._key)
+        if password is None:
+            raise RuntimeError(f"REDIS_AUTH_TOKEN_KEY {self._key!r} not present in secret {self._arn}")
+        return (self._username, password) if self._username else (password,)

--- a/plane_mcp/aws_secrets.py
+++ b/plane_mcp/aws_secrets.py
@@ -1,82 +1,92 @@
-"""AWS Secrets Manager helpers for Redis auth token rotation.
+"""AWS Secrets Manager helpers for rotating Redis / ElastiCache auth tokens."""
 
-Mirrors the pattern in plane-ee/apps/api/plane/utils/aws_secrets.py — TTL-cached
-``get_secret`` keyed by (arn, region), plus a redis-py ``CredentialProvider``
-that reads the current password from the cache on every new Redis connection.
-"""
+from __future__ import annotations
 
 import json
 import os
 import threading
 import time
+from typing import Any
 
-import boto3
 from fastmcp.utilities.logging import get_logger
 from redis import CredentialProvider
 
-_SECRET_CACHE: dict[tuple[str, str], dict] = {}
+logger = get_logger(__name__)
+
+_DEFAULT_TTL_SECONDS = 300
+
+_SECRET_CACHE: dict[tuple[str, str], dict[str, Any]] = {}
 _cache_lock = threading.Lock()
-_logger = get_logger(__name__)
 
 
-def _parse_default_ttl() -> int:
+def _get_ttl_seconds() -> int:
+    """Read ``AWS_SECRET_CACHE_TTL`` at call time, falling back to the default."""
     raw = os.getenv("AWS_SECRET_CACHE_TTL")
     if raw is None:
-        return 300
+        return _DEFAULT_TTL_SECONDS
     try:
         return int(raw)
     except ValueError:
-        _logger.warning("AWS_SECRET_CACHE_TTL=%r is not an integer; using default 300", raw)
-        return 300
+        logger.warning(
+            "AWS_SECRET_CACHE_TTL=%r is not an integer; using default %d",
+            raw,
+            _DEFAULT_TTL_SECONDS,
+        )
+        return _DEFAULT_TTL_SECONDS
 
 
-_DEFAULT_TTL = _parse_default_ttl()
+def _is_fresh(entry: dict[str, Any], ttl: int) -> bool:
+    return time.time() - entry["fetched_at"] < ttl
 
 
-def get_secret(secret_arn: str, region: str, force_refresh: bool = False) -> dict:
-    """Fetch and TTL-cache a secret from AWS Secrets Manager.
+def get_secret(secret_arn: str, region: str, force_refresh: bool = False) -> dict[str, Any]:
+    """Fetch and TTL-cache a JSON secret from AWS Secrets Manager.
 
-    Returns a copy of the parsed JSON secret dict so callers cannot mutate the
-    cached value. The boto3 call is issued outside the cache lock so concurrent
-    readers of fresh entries are not blocked during a refresh; a second check
-    under the lock resolves any race between concurrent refreshers.
+    Args:
+        secret_arn: ARN of the secret.
+        region: AWS region.
+        force_refresh: Bypass the cache.
+
+    Returns:
+        A copy of the parsed JSON dict. Safe to mutate.
     """
+    import boto3  # lazy
+
     cache_key = (secret_arn, region)
+    ttl = _get_ttl_seconds()
 
     if not force_refresh:
         with _cache_lock:
             entry = _SECRET_CACHE.get(cache_key)
-            if entry and time.time() - entry["fetched_at"] < _DEFAULT_TTL:
-                return entry["value"].copy()
+            if entry and _is_fresh(entry, ttl):
+                return dict(entry["value"])
 
     client = boto3.client("secretsmanager", region_name=region)
     response = client.get_secret_value(SecretId=secret_arn)
-    value = json.loads(response["SecretString"])
-    _logger.info(
-        "Refreshed secret from Secrets Manager",
-        extra={"secret_arn": secret_arn},
-    )
+    value: dict[str, Any] = json.loads(response["SecretString"])
+    logger.info("Refreshed secret from Secrets Manager", extra={"secret_arn": secret_arn})
 
     with _cache_lock:
         if not force_refresh:
             entry = _SECRET_CACHE.get(cache_key)
-            if entry and time.time() - entry["fetched_at"] < _DEFAULT_TTL:
-                return entry["value"].copy()
+            if entry and _is_fresh(entry, ttl):
+                # Another thread won the race; reuse their value.
+                return dict(entry["value"])
         _SECRET_CACHE[cache_key] = {"value": value, "fetched_at": time.time()}
 
-    return value.copy()
+    return dict(value)
 
 
 class ElastiCacheCredentialProvider(CredentialProvider):
-    """redis-py credential provider that resolves the password from Secrets Manager.
+    """redis-py credential provider backed by a Secrets Manager secret."""
 
-    ``get_credentials`` is called by redis-py during AUTH on each new connection,
-    so as long as the TTL cache returns a refreshed value after ``AWS_SECRET_CACHE_TTL``
-    seconds, rotated ElastiCache auth tokens are picked up automatically without
-    restarting the server.
-    """
-
-    def __init__(self, secret_arn: str, region: str, token_key: str, username: str | None = None):
+    def __init__(
+        self,
+        secret_arn: str,
+        region: str,
+        token_key: str,
+        username: str | None = None,
+    ) -> None:
         self._arn = secret_arn
         self._region = region
         self._key = token_key
@@ -87,4 +97,6 @@ class ElastiCacheCredentialProvider(CredentialProvider):
         password = secret.get(self._key)
         if password is None:
             raise RuntimeError(f"REDIS_AUTH_TOKEN_KEY {self._key!r} not present in secret {self._arn}")
-        return (self._username, password) if self._username else (password,)
+        if self._username:
+            return (self._username, password)
+        return (password,)

--- a/plane_mcp/aws_secrets.py
+++ b/plane_mcp/aws_secrets.py
@@ -17,30 +17,54 @@ from redis import CredentialProvider
 _SECRET_CACHE: dict[tuple[str, str], dict] = {}
 _cache_lock = threading.Lock()
 _logger = logging.getLogger(__name__)
-_DEFAULT_TTL = int(os.environ.get("AWS_SECRET_CACHE_TTL", 300))
+
+
+def _parse_default_ttl() -> int:
+    raw = os.getenv("AWS_SECRET_CACHE_TTL")
+    if raw is None:
+        return 300
+    try:
+        return int(raw)
+    except ValueError:
+        _logger.warning("AWS_SECRET_CACHE_TTL=%r is not an integer; using default 300", raw)
+        return 300
+
+
+_DEFAULT_TTL = _parse_default_ttl()
 
 
 def get_secret(secret_arn: str, region: str, force_refresh: bool = False) -> dict:
     """Fetch and TTL-cache a secret from AWS Secrets Manager.
 
     Returns a copy of the parsed JSON secret dict so callers cannot mutate the
-    cached value.
+    cached value. The boto3 call is issued outside the cache lock so concurrent
+    readers of fresh entries are not blocked during a refresh; a second check
+    under the lock resolves any race between concurrent refreshers.
     """
     cache_key = (secret_arn, region)
-    with _cache_lock:
-        if not force_refresh and cache_key in _SECRET_CACHE:
-            entry = _SECRET_CACHE[cache_key]
-            if time.time() - entry["fetched_at"] < _DEFAULT_TTL:
+
+    if not force_refresh:
+        with _cache_lock:
+            entry = _SECRET_CACHE.get(cache_key)
+            if entry and time.time() - entry["fetched_at"] < _DEFAULT_TTL:
                 return entry["value"].copy()
-        client = boto3.client("secretsmanager", region_name=region)
-        response = client.get_secret_value(SecretId=secret_arn)
-        value = json.loads(response["SecretString"])
+
+    client = boto3.client("secretsmanager", region_name=region)
+    response = client.get_secret_value(SecretId=secret_arn)
+    value = json.loads(response["SecretString"])
+    _logger.info(
+        "Refreshed secret from Secrets Manager",
+        extra={"secret_arn": secret_arn},
+    )
+
+    with _cache_lock:
+        if not force_refresh:
+            entry = _SECRET_CACHE.get(cache_key)
+            if entry and time.time() - entry["fetched_at"] < _DEFAULT_TTL:
+                return entry["value"].copy()
         _SECRET_CACHE[cache_key] = {"value": value, "fetched_at": time.time()}
-        _logger.info(
-            "Refreshed secret from Secrets Manager",
-            extra={"secret_arn": secret_arn},
-        )
-        return value.copy()
+
+    return value.copy()
 
 
 class ElastiCacheCredentialProvider(CredentialProvider):

--- a/plane_mcp/aws_secrets.py
+++ b/plane_mcp/aws_secrets.py
@@ -6,17 +6,17 @@ that reads the current password from the cache on every new Redis connection.
 """
 
 import json
-import logging
 import os
 import threading
 import time
 
 import boto3
+from fastmcp.utilities.logging import get_logger
 from redis import CredentialProvider
 
 _SECRET_CACHE: dict[tuple[str, str], dict] = {}
 _cache_lock = threading.Lock()
-_logger = logging.getLogger(__name__)
+_logger = get_logger(__name__)
 
 
 def _parse_default_ttl() -> int:

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -1,5 +1,6 @@
 """Plane MCP Server implementation."""
 
+import logging
 import os
 
 from fastmcp import FastMCP
@@ -11,23 +12,71 @@ from mcp.types import Icon
 from plane_mcp.auth import PlaneHeaderAuthProvider, PlaneOAuthProvider
 from plane_mcp.tools import register_tools
 
+logger = logging.getLogger(__name__)
 
-def get_oauth_mcp(base_path: str = "/"):
-    import logging
 
-    logger = logging.getLogger(__name__)
+def _has_aws_credentials() -> bool:
+    # True when either IRSA (AWS_ROLE_ARN) or EKS Pod Identity
+    # (AWS_CONTAINER_CREDENTIALS_FULL_URI) is present. Mirrors plane-ee api service.
+    return bool(os.environ.get("AWS_ROLE_ARN", "") or os.environ.get("AWS_CONTAINER_CREDENTIALS_FULL_URI", ""))
 
+
+def _build_token_store():
     redis_host = os.getenv("REDIS_HOST")
     redis_port = os.getenv("REDIS_PORT")
+    password = os.getenv("REDIS_PASSWORD")
+    secret_arn = os.getenv("ELASTICACHE_SECRET_ARN")
+
+    if password:
+        if not (redis_host and redis_port):
+            raise RuntimeError("REDIS_PASSWORD is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis.")
+        logger.info("Using Redis for token storage (password auth)")
+        return RedisStore(host=redis_host, port=int(redis_port), password=password)
+
+    if secret_arn and _has_aws_credentials():
+        if not (redis_host and redis_port):
+            raise RuntimeError(
+                "ELASTICACHE_SECRET_ARN is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis."
+            )
+
+        from redis.asyncio import Redis
+
+        from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
+
+        region = os.getenv("AWS_REGION", "us-east-1")
+        token_key = os.getenv("REDIS_AUTH_TOKEN_KEY", "authToken")
+
+        secret = get_secret(secret_arn, region)
+        if token_key not in secret:
+            raise RuntimeError(f"REDIS_AUTH_TOKEN_KEY {token_key!r} not present in secret {secret_arn}")
+
+        logger.info("Using Redis for token storage (auth token from Secrets Manager)")
+        client = Redis(
+            host=redis_host,
+            port=int(redis_port),
+            credential_provider=ElastiCacheCredentialProvider(secret_arn, region, token_key),
+            decode_responses=True,
+        )
+        return RedisStore(client=client)
+
+    if secret_arn:
+        logger.warning(
+            "ELASTICACHE_SECRET_ARN is set but IRSA/Pod Identity env vars "
+            "(AWS_ROLE_ARN or AWS_CONTAINER_CREDENTIALS_FULL_URI) are missing — skipping Secrets Manager auth."
+        )
 
     if redis_host and redis_port:
         logger.info("Using Redis for token storage")
-        client_storage = RedisStore(host=redis_host, port=int(redis_port))
-    else:
-        logger.warning(
-            "Using in-memory storage - tokens will be lost on restart! " "Set REDIS_HOST and REDIS_PORT for production."
-        )
-        client_storage = MemoryStore()
+        return RedisStore(host=redis_host, port=int(redis_port))
+
+    logger.warning(
+        "Using in-memory storage - tokens will be lost on restart! Set REDIS_HOST and REDIS_PORT for production."
+    )
+    return MemoryStore()
+
+
+def get_oauth_mcp(base_path: str = "/"):
+    client_storage = _build_token_store()
 
     # Initialize the MCP server
     oauth_mcp = FastMCP(

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -1,10 +1,10 @@
 """Plane MCP Server implementation."""
 
-import logging
 import os
 
 from fastmcp import FastMCP
 from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+from fastmcp.utilities.logging import get_logger
 from key_value.aio.stores.memory import MemoryStore
 from key_value.aio.stores.redis import RedisStore
 from mcp.types import Icon
@@ -12,13 +12,32 @@ from mcp.types import Icon
 from plane_mcp.auth import PlaneHeaderAuthProvider, PlaneOAuthProvider
 from plane_mcp.tools import register_tools
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _has_aws_credentials() -> bool:
     # True when either IRSA (AWS_ROLE_ARN) or EKS Pod Identity
     # (AWS_CONTAINER_CREDENTIALS_FULL_URI) is present. Mirrors plane-ee api service.
     return bool(os.environ.get("AWS_ROLE_ARN", "") or os.environ.get("AWS_CONTAINER_CREDENTIALS_FULL_URI", ""))
+
+
+def _redis_ssl_enabled() -> bool:
+    # ElastiCache requires in-transit encryption (TLS) whenever Redis AUTH tokens
+    # are used, so default to True. Set REDIS_SSL=false to opt out for a plaintext
+    # self-managed Redis.
+    return os.getenv("REDIS_SSL", "true").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _verify_redis_connection(store) -> None:
+    """PING Redis eagerly so a misconfigured/unreachable backend fails loud at
+    startup instead of silently degrading on the first (lazy) token operation."""
+    import asyncio
+
+    try:
+        asyncio.run(store._client.ping())
+    except Exception as exc:
+        raise RuntimeError(f"Redis connection failed during startup PING: {exc}") from exc
+    logger.info("Redis connection verified (PING succeeded)")
 
 
 def _build_token_store():
@@ -31,7 +50,9 @@ def _build_token_store():
         if not (redis_host and redis_port):
             raise RuntimeError("REDIS_PASSWORD is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis.")
         logger.info("Using Redis for token storage (password auth)")
-        return RedisStore(host=redis_host, port=int(redis_port), password=password)
+        store = RedisStore(host=redis_host, port=int(redis_port), password=password)
+        _verify_redis_connection(store)
+        return store
 
     if secret_arn and _has_aws_credentials():
         if not (redis_host and redis_port):
@@ -50,14 +71,18 @@ def _build_token_store():
         if token_key not in secret:
             raise RuntimeError(f"REDIS_AUTH_TOKEN_KEY {token_key!r} not present in secret {secret_arn}")
 
-        logger.info("Using Redis for token storage (auth token from Secrets Manager)")
+        use_ssl = _redis_ssl_enabled()
+        logger.info("Using Redis for token storage (auth token from Secrets Manager, ssl=%s)", use_ssl)
         client = Redis(
             host=redis_host,
             port=int(redis_port),
             credential_provider=ElastiCacheCredentialProvider(secret_arn, region, token_key),
             decode_responses=True,
+            ssl=use_ssl,
         )
-        return RedisStore(client=client)
+        store = RedisStore(client=client)
+        _verify_redis_connection(store)
+        return store
 
     if secret_arn:
         logger.warning(
@@ -67,7 +92,9 @@ def _build_token_store():
 
     if redis_host and redis_port:
         logger.info("Using Redis for token storage")
-        return RedisStore(host=redis_host, port=int(redis_port))
+        store = RedisStore(host=redis_host, port=int(redis_port))
+        _verify_redis_connection(store)
+        return store
 
     logger.warning(
         "Using in-memory storage - tokens will be lost on restart! Set REDIS_HOST and REDIS_PORT for production."

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -1,111 +1,20 @@
-"""Plane MCP Server implementation."""
+"""FastMCP server factories for the three supported transports."""
+
+from __future__ import annotations
 
 import os
 
 from fastmcp import FastMCP
 from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
-from fastmcp.utilities.logging import get_logger
-from key_value.aio.stores.memory import MemoryStore
-from key_value.aio.stores.redis import RedisStore
 from mcp.types import Icon
 
 from plane_mcp.auth import PlaneHeaderAuthProvider, PlaneOAuthProvider
+from plane_mcp.storage import build_token_store
 from plane_mcp.tools import register_tools
 
-logger = get_logger(__name__)
 
-
-def _has_aws_credentials() -> bool:
-    # True when either IRSA (AWS_ROLE_ARN) or EKS Pod Identity
-    # (AWS_CONTAINER_CREDENTIALS_FULL_URI) is present. Mirrors plane-ee api service.
-    return bool(os.environ.get("AWS_ROLE_ARN", "") or os.environ.get("AWS_CONTAINER_CREDENTIALS_FULL_URI", ""))
-
-
-def _redis_ssl_enabled() -> bool:
-    # ElastiCache requires in-transit encryption (TLS) whenever Redis AUTH tokens
-    # are used, so default to True. Set REDIS_SSL=false to opt out for a plaintext
-    # self-managed Redis.
-    return os.getenv("REDIS_SSL", "true").strip().lower() in ("1", "true", "yes", "on")
-
-
-def _verify_redis_connection(store) -> None:
-    """PING Redis eagerly so a misconfigured/unreachable backend fails loud at
-    startup instead of silently degrading on the first (lazy) token operation."""
-    import asyncio
-
-    try:
-        asyncio.run(store._client.ping())
-    except Exception as exc:
-        raise RuntimeError(f"Redis connection failed during startup PING: {exc}") from exc
-    logger.info("Redis connection verified (PING succeeded)")
-
-
-def _build_token_store():
-    redis_host = os.getenv("REDIS_HOST")
-    redis_port = os.getenv("REDIS_PORT")
-    password = os.getenv("REDIS_PASSWORD")
-    secret_arn = os.getenv("ELASTICACHE_SECRET_ARN")
-
-    if password:
-        if not (redis_host and redis_port):
-            raise RuntimeError("REDIS_PASSWORD is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis.")
-        logger.info("Using Redis for token storage (password auth)")
-        store = RedisStore(host=redis_host, port=int(redis_port), password=password)
-        _verify_redis_connection(store)
-        return store
-
-    if secret_arn and _has_aws_credentials():
-        if not (redis_host and redis_port):
-            raise RuntimeError(
-                "ELASTICACHE_SECRET_ARN is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis."
-            )
-
-        from redis.asyncio import Redis
-
-        from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
-
-        region = os.getenv("AWS_REGION", "us-east-1")
-        token_key = os.getenv("REDIS_AUTH_TOKEN_KEY", "authToken")
-
-        secret = get_secret(secret_arn, region)
-        if token_key not in secret:
-            raise RuntimeError(f"REDIS_AUTH_TOKEN_KEY {token_key!r} not present in secret {secret_arn}")
-
-        use_ssl = _redis_ssl_enabled()
-        logger.info("Using Redis for token storage (auth token from Secrets Manager, ssl=%s)", use_ssl)
-        client = Redis(
-            host=redis_host,
-            port=int(redis_port),
-            credential_provider=ElastiCacheCredentialProvider(secret_arn, region, token_key),
-            decode_responses=True,
-            ssl=use_ssl,
-        )
-        store = RedisStore(client=client)
-        _verify_redis_connection(store)
-        return store
-
-    if secret_arn:
-        logger.warning(
-            "ELASTICACHE_SECRET_ARN is set but IRSA/Pod Identity env vars "
-            "(AWS_ROLE_ARN or AWS_CONTAINER_CREDENTIALS_FULL_URI) are missing — skipping Secrets Manager auth."
-        )
-
-    if redis_host and redis_port:
-        logger.info("Using Redis for token storage")
-        store = RedisStore(host=redis_host, port=int(redis_port))
-        _verify_redis_connection(store)
-        return store
-
-    logger.warning(
-        "Using in-memory storage - tokens will be lost on restart! Set REDIS_HOST and REDIS_PORT for production."
-    )
-    return MemoryStore()
-
-
-def get_oauth_mcp(base_path: str = "/"):
-    client_storage = _build_token_store()
-
-    # Initialize the MCP server
+def get_oauth_mcp(base_path: str = "/") -> FastMCP:
+    """Build the FastMCP instance for the OAuth HTTP / SSE transports."""
     oauth_mcp = FastMCP(
         "Plane MCP Server",
         icons=[Icon(src="https://plane.so/favicon.ico", alt="Plane MCP Server")],
@@ -116,7 +25,7 @@ def get_oauth_mcp(base_path: str = "/"):
             base_url=f"{os.getenv('PLANE_OAUTH_PROVIDER_BASE_URL')}{base_path}",
             plane_base_url=os.getenv("PLANE_BASE_URL", ""),
             plane_internal_base_url=os.getenv("PLANE_INTERNAL_BASE_URL", ""),
-            client_storage=client_storage,
+            client_storage=build_token_store(),
             required_scopes=["read", "write"],
             allowed_client_redirect_uris=[
                 # Localhost only for http (dynamic ports from MCP clients)

--- a/plane_mcp/storage.py
+++ b/plane_mcp/storage.py
@@ -1,0 +1,166 @@
+"""OAuth token storage backends.
+
+Selects and verifies the storage backing the OAuth token cache used by the
+HTTP / SSE transports. Priority order (highest first):
+
+1. ``REDIS_PASSWORD`` + ``REDIS_HOST``/``REDIS_PORT`` → Redis with a static password.
+2. ``ELASTICACHE_SECRET_ARN`` + IRSA (``AWS_ROLE_ARN``) or EKS Pod Identity
+   (``AWS_CONTAINER_CREDENTIALS_FULL_URI``) + host/port → Redis with a rotating
+   AUTH token from AWS Secrets Manager.
+3. ``REDIS_HOST`` + ``REDIS_PORT`` → plain Redis (no auth).
+4. None of the above → in-memory store (dev only; tokens lost on restart).
+
+Misconfigurations raise ``RuntimeError`` at startup. Reachability is verified
+eagerly with a synchronous PING.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastmcp.utilities.logging import get_logger
+from key_value.aio.stores.memory import MemoryStore
+from key_value.aio.stores.redis import RedisStore
+
+logger = get_logger(__name__)
+
+
+def _has_aws_credentials() -> bool:
+    """True when IRSA or EKS Pod Identity env vars are set."""
+    return bool(os.getenv("AWS_ROLE_ARN") or os.getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI"))
+
+
+def _redis_ssl_enabled(default: bool) -> bool:
+    """Read REDIS_SSL with the caller's default. ElastiCache paths default True."""
+    raw = os.getenv("REDIS_SSL")
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _ping_redis(
+    host: str,
+    port: int,
+    *,
+    password: str | None = None,
+    ssl: bool = False,
+    timeout_seconds: float = 5.0,
+) -> None:
+    """Verify Redis reachability with a one-shot synchronous PING.
+
+    Raises ``RuntimeError`` on any connection or auth failure.
+    """
+    import redis  # local: only loaded when Redis is configured
+
+    client = redis.Redis(
+        host=host,
+        port=port,
+        password=password,
+        ssl=ssl,
+        socket_connect_timeout=timeout_seconds,
+        socket_timeout=timeout_seconds,
+    )
+    try:
+        client.ping()
+    except Exception as exc:
+        raise RuntimeError(f"Redis connection failed during startup PING: {exc}") from exc
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+    logger.info("Redis connection verified (PING succeeded)")
+
+
+def build_token_store() -> Any:
+    """Select and build the OAuth token store from environment variables.
+
+    See the module docstring for the selection priority. The returned object
+    is handed verbatim to ``PlaneOAuthProvider`` as ``client_storage``.
+    """
+    redis_host = os.getenv("REDIS_HOST")
+    redis_port = os.getenv("REDIS_PORT")
+    password = os.getenv("REDIS_PASSWORD")
+    secret_arn = os.getenv("ELASTICACHE_SECRET_ARN")
+
+    # 1. Static-password Redis
+    if password:
+        if not (redis_host and redis_port):
+            raise RuntimeError("REDIS_PASSWORD is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis.")
+        if secret_arn:
+            logger.warning(
+                "Both REDIS_PASSWORD and ELASTICACHE_SECRET_ARN set — static password wins, Secrets Manager ignored."
+            )
+
+        # REDIS_SSL defaults False here: plain Redis is the common case for
+        # static-password deployments. Set REDIS_SSL=true for TLS-fronted Redis.
+        use_ssl = _redis_ssl_enabled(default=False)
+        _ping_redis(redis_host, int(redis_port), password=password, ssl=use_ssl)
+        store = RedisStore(host=redis_host, port=int(redis_port), password=password)
+        logger.info(
+            "Token store: Redis (auth=password, host=%s, port=%s, ssl=%s)",
+            redis_host,
+            redis_port,
+            use_ssl,
+        )
+        return store
+
+    # 2. ElastiCache + Secrets Manager
+    if secret_arn and _has_aws_credentials():
+        if not (redis_host and redis_port):
+            raise RuntimeError(
+                "ELASTICACHE_SECRET_ARN is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis."
+            )
+
+        # Lazy imports keep the AWS path's deps optional.
+        from redis.asyncio import Redis as AsyncRedis
+
+        from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
+
+        region = os.getenv("AWS_REGION", "us-east-1")
+        token_key = os.getenv("REDIS_AUTH_TOKEN_KEY", "authToken")
+
+        # Eager fetch — a missing key fails startup, not the first OAuth flow.
+        secret = get_secret(secret_arn, region)
+        if token_key not in secret:
+            raise RuntimeError(f"REDIS_AUTH_TOKEN_KEY {token_key!r} not present in secret {secret_arn}")
+
+        use_ssl = _redis_ssl_enabled(default=True)
+        _ping_redis(redis_host, int(redis_port), password=secret[token_key], ssl=use_ssl)
+
+        async_client = AsyncRedis(
+            host=redis_host,
+            port=int(redis_port),
+            credential_provider=ElastiCacheCredentialProvider(secret_arn, region, token_key),
+            decode_responses=True,
+            ssl=use_ssl,
+        )
+        store = RedisStore(client=async_client)
+        logger.info(
+            "Token store: Redis (auth=secrets-manager, host=%s, port=%s, ssl=%s, region=%s)",
+            redis_host,
+            redis_port,
+            use_ssl,
+            region,
+        )
+        return store
+
+    if secret_arn:
+        logger.warning(
+            "ELASTICACHE_SECRET_ARN is set but IRSA / Pod Identity env vars "
+            "(AWS_ROLE_ARN or AWS_CONTAINER_CREDENTIALS_FULL_URI) are missing — "
+            "skipping Secrets Manager auth."
+        )
+
+    # 3. Plain Redis
+    if redis_host and redis_port:
+        _ping_redis(redis_host, int(redis_port))
+        store = RedisStore(host=redis_host, port=int(redis_port))
+        logger.info("Token store: Redis (auth=none, host=%s, port=%s)", redis_host, redis_port)
+        return store
+
+    # 4. In-memory fallback
+    logger.warning("Token store: in-memory (tokens lost on restart). Set REDIS_HOST and REDIS_PORT for production.")
+    return MemoryStore()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
     "mcp==1.26.0",
     "PyJWT>=2.12.0",
     "authlib>=1.6.9",
+    "boto3>=1.34.0",
+    # pydocket 0.16.6 (pinned by fastmcp 2.14.4) imports `FakeConnection` from
+    # `fakeredis.aioredis`, which was removed in fakeredis 2.35.0.
+    "fakeredis[lua]>=2.32.1,<2.35.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_aws_secrets.py
+++ b/tests/test_aws_secrets.py
@@ -1,0 +1,196 @@
+"""Unit tests for plane_mcp.aws_secrets and the Redis token-store resolver."""
+
+import json
+
+import boto3
+import pytest
+from botocore.stub import Stubber
+from key_value.aio.stores.memory import MemoryStore
+from key_value.aio.stores.redis import RedisStore
+
+from plane_mcp import aws_secrets
+from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
+from plane_mcp.server import _build_token_store
+
+ARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test"
+REGION = "us-east-1"
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    aws_secrets._SECRET_CACHE.clear()
+    for k in (
+        "REDIS_HOST",
+        "REDIS_PORT",
+        "REDIS_PASSWORD",
+        "ELASTICACHE_SECRET_ARN",
+        "REDIS_AUTH_TOKEN_KEY",
+        "AWS_REGION",
+        "AWS_ROLE_ARN",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+    aws_secrets._SECRET_CACHE.clear()
+
+
+def _stub_secrets(monkeypatch, payloads: list[dict]):
+    """Patch boto3.client to return a Stubber-backed Secrets Manager client.
+
+    Each entry in ``payloads`` becomes one queued ``get_secret_value`` response;
+    unexpected calls raise.
+    """
+    client = boto3.client("secretsmanager", region_name=REGION)
+    stubber = Stubber(client)
+    for payload in payloads:
+        stubber.add_response(
+            "get_secret_value",
+            {"SecretString": json.dumps(payload)},
+            expected_params={"SecretId": ARN},
+        )
+    stubber.activate()
+    monkeypatch.setattr(aws_secrets.boto3, "client", lambda *a, **k: client)
+    return stubber
+
+
+def _forbid_boto3(monkeypatch):
+    def _explode(*_a, **_k):
+        raise AssertionError("Unexpected boto3.client() call")
+
+    monkeypatch.setattr(aws_secrets.boto3, "client", _explode)
+
+
+def test_get_secret_caches_within_ttl(monkeypatch):
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "p1"}])
+    assert get_secret(ARN, REGION) == {"authToken": "p1"}
+    assert get_secret(ARN, REGION) == {"authToken": "p1"}
+    stubber.assert_no_pending_responses()
+
+
+def test_get_secret_refreshes_after_ttl(monkeypatch):
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "p1"}, {"authToken": "p2"}])
+    monkeypatch.setattr(aws_secrets, "_DEFAULT_TTL", 0)
+    assert get_secret(ARN, REGION)["authToken"] == "p1"
+    assert get_secret(ARN, REGION)["authToken"] == "p2"
+    stubber.assert_no_pending_responses()
+
+
+def test_get_secret_force_refresh(monkeypatch):
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "p1"}, {"authToken": "p2"}])
+    assert get_secret(ARN, REGION)["authToken"] == "p1"
+    assert get_secret(ARN, REGION, force_refresh=True)["authToken"] == "p2"
+    stubber.assert_no_pending_responses()
+
+
+def test_get_secret_returns_copy(monkeypatch):
+    _stub_secrets(monkeypatch, [{"authToken": "p1"}])
+    first = get_secret(ARN, REGION)
+    first["authToken"] = "mutated"
+    second = get_secret(ARN, REGION)
+    assert second["authToken"] == "p1"
+
+
+def test_credential_provider_returns_password(monkeypatch):
+    _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
+    provider = ElastiCacheCredentialProvider(ARN, REGION, "authToken")
+    assert provider.get_credentials() == ("secret-pw",)
+
+
+def test_credential_provider_with_username(monkeypatch):
+    _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
+    provider = ElastiCacheCredentialProvider(ARN, REGION, "authToken", username="alice")
+    assert provider.get_credentials() == ("alice", "secret-pw")
+
+
+def test_credential_provider_missing_key_raises(monkeypatch):
+    _stub_secrets(monkeypatch, [{"otherKey": "value"}])
+    provider = ElastiCacheCredentialProvider(ARN, REGION, "authToken")
+    with pytest.raises(RuntimeError, match="authToken"):
+        provider.get_credentials()
+
+
+def test_build_token_store_no_env_returns_memory_store():
+    assert isinstance(_build_token_store(), MemoryStore)
+
+
+def test_build_token_store_host_port_only_returns_redis(monkeypatch):
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    _forbid_boto3(monkeypatch)
+    assert isinstance(_build_token_store(), RedisStore)
+
+
+def test_build_token_store_password_wins_over_arn(monkeypatch):
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_PASSWORD", "pw")
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    _forbid_boto3(monkeypatch)
+    assert isinstance(_build_token_store(), RedisStore)
+
+
+def test_build_token_store_password_without_host_port_raises(monkeypatch):
+    monkeypatch.setenv("REDIS_PASSWORD", "pw")
+    with pytest.raises(RuntimeError, match="REDIS_PASSWORD"):
+        _build_token_store()
+
+
+def test_build_token_store_arn_without_host_port_raises(monkeypatch):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    with pytest.raises(RuntimeError, match="ELASTICACHE_SECRET_ARN"):
+        _build_token_store()
+
+
+def test_build_token_store_arn_without_irsa_skips_sm(monkeypatch, caplog):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    _forbid_boto3(monkeypatch)
+
+    with caplog.at_level("WARNING", logger="plane_mcp.server"):
+        store = _build_token_store()
+
+    assert isinstance(store, RedisStore)
+    assert any("IRSA/Pod Identity" in rec.message for rec in caplog.records)
+
+
+def test_build_token_store_arn_with_aws_role_arn_activates_sm(monkeypatch):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
+    assert isinstance(_build_token_store(), RedisStore)
+    stubber.assert_no_pending_responses()
+
+
+def test_build_token_store_arn_with_pod_identity_activates_sm(monkeypatch):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/v1/credentials")
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
+    assert isinstance(_build_token_store(), RedisStore)
+    stubber.assert_no_pending_responses()
+
+
+def test_build_token_store_arn_missing_token_key_raises(monkeypatch):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    _stub_secrets(monkeypatch, [{"otherKey": "value"}])
+    with pytest.raises(RuntimeError, match="REDIS_AUTH_TOKEN_KEY"):
+        _build_token_store()
+
+
+def test_build_token_store_custom_token_key(monkeypatch):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    monkeypatch.setenv("REDIS_AUTH_TOKEN_KEY", "token")
+    _stub_secrets(monkeypatch, [{"token": "secret-pw"}])
+    assert isinstance(_build_token_store(), RedisStore)

--- a/tests/test_aws_secrets.py
+++ b/tests/test_aws_secrets.py
@@ -1,8 +1,16 @@
-"""Unit tests for plane_mcp.aws_secrets and the Redis token-store resolver."""
+"""Unit tests for plane_mcp.aws_secrets and the Redis token-store resolver.
+
+These tests run without a live Redis or AWS environment. boto3 is patched to
+return canned responses via ``botocore.stub.Stubber``; redis-py is patched at
+the module level so the synchronous PING never hits a real socket.
+"""
+
+from __future__ import annotations
 
 import json
 import logging
 import time
+from typing import Any
 
 import boto3
 import pytest
@@ -10,17 +18,33 @@ from botocore.stub import Stubber
 from key_value.aio.stores.memory import MemoryStore
 from key_value.aio.stores.redis import RedisStore
 
-from plane_mcp import aws_secrets, server
+from plane_mcp import aws_secrets, storage
 from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
-from plane_mcp.server import _build_token_store
+from plane_mcp.storage import build_token_store
 
 ARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test"
 REGION = "us-east-1"
 
+# Dummy AWS credentials so boto3's credential resolver is short-circuited and
+# never tries to hit the IMDS endpoint when AWS_CONTAINER_CREDENTIALS_FULL_URI
+# is set by a test fixture. These values are inert — boto3 calls are stubbed.
+_FAKE_AWS_ENV = {
+    "AWS_ACCESS_KEY_ID": "test",
+    "AWS_SECRET_ACCESS_KEY": "test",
+    "AWS_SESSION_TOKEN": "test",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def _reset_state(monkeypatch):
+    """Per-test isolation: clear the secret cache and unset Redis/AWS env vars."""
     aws_secrets._SECRET_CACHE.clear()
+
     for k in (
         "REDIS_HOST",
         "REDIS_PORT",
@@ -31,17 +55,26 @@ def _reset_state(monkeypatch):
         "AWS_REGION",
         "AWS_ROLE_ARN",
         "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_SECRET_CACHE_TTL",
     ):
         monkeypatch.delenv(k, raising=False)
+
+    # Inject inert AWS creds so boto3 never reaches out to IMDS even when a
+    # test sets AWS_CONTAINER_CREDENTIALS_FULL_URI to a fake endpoint.
+    for k, v in _FAKE_AWS_ENV.items():
+        monkeypatch.setenv(k, v)
+
     yield
     aws_secrets._SECRET_CACHE.clear()
 
 
-def _stub_secrets(monkeypatch, payloads: list[dict]):
-    """Patch boto3.client to return a Stubber-backed Secrets Manager client.
+def _stub_secrets(monkeypatch, payloads: list[dict[str, Any]]) -> Stubber:
+    """Return a Stubber-backed Secrets Manager client and patch boto3.client.
 
-    Each entry in ``payloads`` becomes one queued ``get_secret_value`` response;
-    unexpected calls raise.
+    Each entry in ``payloads`` becomes one queued ``get_secret_value``
+    response. The boto3 client is created inside the patch so the dummy AWS
+    credentials in the fixture are used; the real IMDS endpoint is never
+    contacted.
     """
     client = boto3.client("secretsmanager", region_name=REGION)
     stubber = Stubber(client)
@@ -52,21 +85,30 @@ def _stub_secrets(monkeypatch, payloads: list[dict]):
             expected_params={"SecretId": ARN},
         )
     stubber.activate()
-    monkeypatch.setattr(aws_secrets.boto3, "client", lambda *a, **k: client)
+
+    # Patch the boto3 reference that aws_secrets imports lazily.
+    def _client_factory(*_a, **_k):
+        return client
+
+    monkeypatch.setattr("boto3.client", _client_factory)
     return stubber
 
 
-def _forbid_boto3(monkeypatch):
-    def _explode(*_a, **_k):
-        raise AssertionError("Unexpected boto3.client() call")
+def _forbid_boto3_secretsmanager(monkeypatch) -> None:
+    """Fail the test if anything calls boto3.client('secretsmanager', ...)."""
 
-    monkeypatch.setattr(aws_secrets.boto3, "client", _explode)
+    def _explode(service_name=None, *_a, **_k):
+        if service_name == "secretsmanager":
+            raise AssertionError("Unexpected boto3.client('secretsmanager', ...) call")
+        return boto3.session.Session().client(service_name, *_a, **_k)
+
+    monkeypatch.setattr("boto3.client", _explode)
 
 
 @pytest.fixture
-def no_verify(monkeypatch):
-    """Skip the eager Redis PING so store-resolution tests need no live Redis."""
-    monkeypatch.setattr(server, "_verify_redis_connection", lambda store: None)
+def no_ping(monkeypatch):
+    """Skip the synchronous Redis PING so store-resolution tests need no Redis."""
+    monkeypatch.setattr(storage, "_ping_redis", lambda *a, **kw: None)
 
 
 @pytest.fixture
@@ -74,7 +116,7 @@ def capture_log(caplog):
     """Capture records from a fastmcp-namespaced logger.
 
     The ``fastmcp`` logger sets ``propagate=False``, so caplog's root handler
-    never sees these records — attach it directly to the target logger instead.
+    never sees these records — attach it directly to the target logger.
     """
 
     def _capture(logger_name: str):
@@ -86,6 +128,11 @@ def capture_log(caplog):
     return _capture
 
 
+# ---------------------------------------------------------------------------
+# get_secret — caching & race handling
+# ---------------------------------------------------------------------------
+
+
 def test_get_secret_caches_within_ttl(monkeypatch):
     stubber = _stub_secrets(monkeypatch, [{"authToken": "p1"}])
     assert get_secret(ARN, REGION) == {"authToken": "p1"}
@@ -95,7 +142,7 @@ def test_get_secret_caches_within_ttl(monkeypatch):
 
 def test_get_secret_refreshes_after_ttl(monkeypatch):
     stubber = _stub_secrets(monkeypatch, [{"authToken": "p1"}, {"authToken": "p2"}])
-    monkeypatch.setattr(aws_secrets, "_DEFAULT_TTL", 0)
+    monkeypatch.setenv("AWS_SECRET_CACHE_TTL", "0")
     assert get_secret(ARN, REGION)["authToken"] == "p1"
     assert get_secret(ARN, REGION)["authToken"] == "p2"
     stubber.assert_no_pending_responses()
@@ -116,20 +163,20 @@ def test_get_secret_returns_copy(monkeypatch):
     assert second["authToken"] == "p1"
 
 
-def test_parse_default_ttl_valid(monkeypatch):
+def test_get_ttl_seconds_valid(monkeypatch):
     monkeypatch.setenv("AWS_SECRET_CACHE_TTL", "60")
-    assert aws_secrets._parse_default_ttl() == 60
+    assert aws_secrets._get_ttl_seconds() == 60
 
 
-def test_parse_default_ttl_unset(monkeypatch):
+def test_get_ttl_seconds_unset(monkeypatch):
     monkeypatch.delenv("AWS_SECRET_CACHE_TTL", raising=False)
-    assert aws_secrets._parse_default_ttl() == 300
+    assert aws_secrets._get_ttl_seconds() == 300
 
 
-def test_parse_default_ttl_invalid_falls_back(monkeypatch, capture_log):
+def test_get_ttl_seconds_invalid_falls_back(monkeypatch, capture_log):
     caplog = capture_log("fastmcp.plane_mcp.aws_secrets")
     monkeypatch.setenv("AWS_SECRET_CACHE_TTL", "not-a-number")
-    assert aws_secrets._parse_default_ttl() == 300
+    assert aws_secrets._get_ttl_seconds() == 300
     assert any("not an integer" in rec.message for rec in caplog.records)
 
 
@@ -138,13 +185,12 @@ def test_get_secret_concurrent_race_uses_existing_fresh_entry(monkeypatch):
     existing fresh entry rather than overwriting it."""
     stubber = _stub_secrets(monkeypatch, [{"authToken": "ours"}])
 
-    # Simulate a racing thread that wrote a fresh entry while our fetch was in
-    # flight, by pre-populating the cache after we've passed the fast-path check
-    # but before the write-back. We do that by patching json.loads to inject.
+    # Simulate a racing thread that wrote a fresh entry after our fast-path
+    # check passed but before our write-back. We do that by injecting into
+    # json.loads — which runs between the boto3 call and the lock re-check.
     original_loads = aws_secrets.json.loads
 
     def _injecting_loads(s):
-        # Another thread "won" the race and wrote first.
         aws_secrets._SECRET_CACHE[(ARN, REGION)] = {
             "value": {"authToken": "theirs"},
             "fetched_at": time.time(),
@@ -160,10 +206,8 @@ def test_get_secret_concurrent_race_uses_existing_fresh_entry(monkeypatch):
 
 
 def test_get_secret_force_refresh_overwrites_race_winner(monkeypatch):
-    """force_refresh=True always installs the freshly-fetched value, ignoring
-    any racing writer."""
+    """``force_refresh=True`` always installs the freshly-fetched value."""
     stubber = _stub_secrets(monkeypatch, [{"authToken": "forced"}])
-
     original_loads = aws_secrets.json.loads
 
     def _injecting_loads(s):
@@ -179,6 +223,11 @@ def test_get_secret_force_refresh_overwrites_race_winner(monkeypatch):
     assert result == {"authToken": "forced"}
     assert aws_secrets._SECRET_CACHE[(ARN, REGION)]["value"] == {"authToken": "forced"}
     stubber.assert_no_pending_responses()
+
+
+# ---------------------------------------------------------------------------
+# ElastiCacheCredentialProvider
+# ---------------------------------------------------------------------------
 
 
 def test_credential_provider_returns_password(monkeypatch):
@@ -200,70 +249,80 @@ def test_credential_provider_missing_key_raises(monkeypatch):
         provider.get_credentials()
 
 
+# ---------------------------------------------------------------------------
+# _build_token_store — backend selection
+# ---------------------------------------------------------------------------
+
+
 def test_build_token_store_no_env_returns_memory_store():
-    assert isinstance(_build_token_store(), MemoryStore)
+    assert isinstance(build_token_store(), MemoryStore)
 
 
-def test_build_token_store_host_port_only_returns_redis(monkeypatch, no_verify):
+def test_build_token_store_host_port_only_returns_redis(monkeypatch, no_ping):
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
-    _forbid_boto3(monkeypatch)
-    assert isinstance(_build_token_store(), RedisStore)
+    _forbid_boto3_secretsmanager(monkeypatch)
+    assert isinstance(build_token_store(), RedisStore)
 
 
-def test_build_token_store_password_wins_over_arn(monkeypatch, no_verify):
+def test_build_token_store_password_wins_over_arn(monkeypatch, no_ping, capture_log):
+    caplog = capture_log("fastmcp.plane_mcp.storage")
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("REDIS_PASSWORD", "pw")
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
-    _forbid_boto3(monkeypatch)
-    assert isinstance(_build_token_store(), RedisStore)
+    _forbid_boto3_secretsmanager(monkeypatch)
+
+    assert isinstance(build_token_store(), RedisStore)
+    assert any("static password wins" in rec.message for rec in caplog.records), (
+        "Expected a warning when both REDIS_PASSWORD and ELASTICACHE_SECRET_ARN are set"
+    )
 
 
 def test_build_token_store_password_without_host_port_raises(monkeypatch):
     monkeypatch.setenv("REDIS_PASSWORD", "pw")
     with pytest.raises(RuntimeError, match="REDIS_PASSWORD"):
-        _build_token_store()
+        build_token_store()
 
 
 def test_build_token_store_arn_without_host_port_raises(monkeypatch):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
     with pytest.raises(RuntimeError, match="ELASTICACHE_SECRET_ARN"):
-        _build_token_store()
+        build_token_store()
 
 
-def test_build_token_store_arn_without_irsa_skips_sm(monkeypatch, capture_log, no_verify):
-    caplog = capture_log("fastmcp.plane_mcp.server")
+def test_build_token_store_arn_without_irsa_skips_sm(monkeypatch, capture_log, no_ping):
+    caplog = capture_log("fastmcp.plane_mcp.storage")
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
-    _forbid_boto3(monkeypatch)
+    _forbid_boto3_secretsmanager(monkeypatch)
 
-    store = _build_token_store()
+    store = build_token_store()
 
     assert isinstance(store, RedisStore)
-    assert any("IRSA/Pod Identity" in rec.message for rec in caplog.records)
+    assert any("IRSA / Pod Identity" in rec.message for rec in caplog.records)
 
 
-def test_build_token_store_arn_with_aws_role_arn_activates_sm(monkeypatch, no_verify):
+def test_build_token_store_arn_with_aws_role_arn_activates_sm(monkeypatch, no_ping):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
     stubber = _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
-    assert isinstance(_build_token_store(), RedisStore)
+    assert isinstance(build_token_store(), RedisStore)
     stubber.assert_no_pending_responses()
 
 
-def test_build_token_store_arn_with_pod_identity_activates_sm(monkeypatch, no_verify):
+def test_build_token_store_arn_with_pod_identity_activates_sm(monkeypatch, no_ping):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://169.254.170.23/v1/credentials")
     stubber = _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
-    assert isinstance(_build_token_store(), RedisStore)
+    assert isinstance(build_token_store(), RedisStore)
     stubber.assert_no_pending_responses()
 
 
@@ -274,24 +333,29 @@ def test_build_token_store_arn_missing_token_key_raises(monkeypatch):
     monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
     _stub_secrets(monkeypatch, [{"otherKey": "value"}])
     with pytest.raises(RuntimeError, match="REDIS_AUTH_TOKEN_KEY"):
-        _build_token_store()
+        build_token_store()
 
 
-def test_build_token_store_custom_token_key(monkeypatch, no_verify):
+def test_build_token_store_custom_token_key(monkeypatch, no_ping):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
     monkeypatch.setenv("REDIS_AUTH_TOKEN_KEY", "token")
     _stub_secrets(monkeypatch, [{"token": "secret-pw"}])
-    assert isinstance(_build_token_store(), RedisStore)
+    assert isinstance(build_token_store(), RedisStore)
 
 
-def _capture_async_redis_kwargs(monkeypatch) -> dict:
-    """Patch redis.asyncio.Redis to record the kwargs the secret path builds it with."""
+# ---------------------------------------------------------------------------
+# TLS on the Secrets Manager path
+# ---------------------------------------------------------------------------
+
+
+def _capture_async_redis_kwargs(monkeypatch) -> dict[str, Any]:
+    """Patch redis.asyncio.Redis to record the kwargs the SM path builds with."""
     import redis.asyncio as aioredis
 
-    captured: dict = {}
+    captured: dict[str, Any] = {}
 
     class _FakeAsyncRedis:
         def __init__(self, **kwargs):
@@ -301,7 +365,7 @@ def _capture_async_redis_kwargs(monkeypatch) -> dict:
     return captured
 
 
-def test_build_token_store_secret_path_uses_tls_by_default(monkeypatch, no_verify):
+def test_build_token_store_secret_path_uses_tls_by_default(monkeypatch, no_ping):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
@@ -309,11 +373,11 @@ def test_build_token_store_secret_path_uses_tls_by_default(monkeypatch, no_verif
     _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
     captured = _capture_async_redis_kwargs(monkeypatch)
 
-    _build_token_store()
+    build_token_store()
     assert captured["ssl"] is True
 
 
-def test_build_token_store_secret_path_ssl_can_be_disabled(monkeypatch, no_verify):
+def test_build_token_store_secret_path_ssl_can_be_disabled(monkeypatch, no_ping):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
@@ -322,51 +386,97 @@ def test_build_token_store_secret_path_ssl_can_be_disabled(monkeypatch, no_verif
     _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
     captured = _capture_async_redis_kwargs(monkeypatch)
 
-    _build_token_store()
+    build_token_store()
     assert captured["ssl"] is False
 
 
 @pytest.mark.parametrize(
-    "value,expected",
+    "value,default,expected",
     [
-        (None, True),
-        ("true", True),
-        ("True", True),
-        ("1", True),
-        ("yes", True),
-        ("on", True),
-        ("false", False),
-        ("0", False),
-        ("no", False),
-        ("", False),
+        # Unset: caller's default wins.
+        (None, True, True),
+        (None, False, False),
+        # Truthy values override default=False.
+        ("true", False, True),
+        ("True", False, True),
+        ("1", False, True),
+        ("yes", False, True),
+        ("on", False, True),
+        # Falsy values override default=True.
+        ("false", True, False),
+        ("0", True, False),
+        ("no", True, False),
+        ("", True, False),
     ],
 )
-def test_redis_ssl_enabled(monkeypatch, value, expected):
+def test_redis_ssl_enabled(monkeypatch, value, default, expected):
     if value is None:
         monkeypatch.delenv("REDIS_SSL", raising=False)
     else:
         monkeypatch.setenv("REDIS_SSL", value)
-    assert server._redis_ssl_enabled() is expected
+    assert storage._redis_ssl_enabled(default=default) is expected
 
 
-def test_verify_redis_connection_succeeds():
-    class _Client:
-        async def ping(self):
-            return True
+def test_password_path_honors_redis_ssl_true(monkeypatch, no_ping):
+    """REDIS_PASSWORD + REDIS_SSL=true must produce an SSL-enabled connection."""
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_PASSWORD", "pw")
+    monkeypatch.setenv("REDIS_SSL", "true")
+    _forbid_boto3_secretsmanager(monkeypatch)
 
-    class _Store:
-        _client = _Client()
+    captured: list[dict[str, Any]] = []
+    monkeypatch.setattr(storage, "_ping_redis", lambda *a, **kw: captured.append(kw))
 
-    server._verify_redis_connection(_Store())  # should not raise
+    build_token_store()
+    assert captured and captured[0]["ssl"] is True
 
 
-def test_verify_redis_connection_raises_on_failure():
-    class _Client:
-        async def ping(self):
-            raise OSError("connection refused")
+# ---------------------------------------------------------------------------
+# _ping_redis — eager reachability check
+# ---------------------------------------------------------------------------
 
-    class _Store:
-        _client = _Client()
 
+def _patch_sync_redis(monkeypatch, *, ping_result=None, ping_exc: Exception | None = None):
+    """Replace ``redis.Redis`` with a fake whose ``ping`` is scripted.
+
+    Returns the list that will receive constructor kwargs for assertions.
+    """
+    import redis
+
+    constructor_calls: list[dict[str, Any]] = []
+
+    class _FakeSyncRedis:
+        def __init__(self, **kwargs):
+            constructor_calls.append(kwargs)
+
+        def ping(self):
+            if ping_exc is not None:
+                raise ping_exc
+            return ping_result
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(redis, "Redis", _FakeSyncRedis)
+    return constructor_calls
+
+
+def test_ping_redis_succeeds(monkeypatch):
+    _patch_sync_redis(monkeypatch, ping_result=True)
+    storage._ping_redis("localhost", 6379)  # should not raise
+
+
+def test_ping_redis_raises_on_failure(monkeypatch):
+    _patch_sync_redis(monkeypatch, ping_exc=OSError("connection refused"))
     with pytest.raises(RuntimeError, match="Redis connection failed during startup PING"):
-        server._verify_redis_connection(_Store())
+        storage._ping_redis("localhost", 6379)
+
+
+def test_ping_redis_passes_through_credentials_and_ssl(monkeypatch):
+    calls = _patch_sync_redis(monkeypatch, ping_result=True)
+    storage._ping_redis("redis.example.com", 6380, password="pw", ssl=True)
+    assert calls[0]["host"] == "redis.example.com"
+    assert calls[0]["port"] == 6380
+    assert calls[0]["password"] == "pw"
+    assert calls[0]["ssl"] is True

--- a/tests/test_aws_secrets.py
+++ b/tests/test_aws_secrets.py
@@ -1,6 +1,7 @@
 """Unit tests for plane_mcp.aws_secrets and the Redis token-store resolver."""
 
 import json
+import logging
 import time
 
 import boto3
@@ -9,7 +10,7 @@ from botocore.stub import Stubber
 from key_value.aio.stores.memory import MemoryStore
 from key_value.aio.stores.redis import RedisStore
 
-from plane_mcp import aws_secrets
+from plane_mcp import aws_secrets, server
 from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
 from plane_mcp.server import _build_token_store
 
@@ -24,6 +25,7 @@ def _reset_state(monkeypatch):
         "REDIS_HOST",
         "REDIS_PORT",
         "REDIS_PASSWORD",
+        "REDIS_SSL",
         "ELASTICACHE_SECRET_ARN",
         "REDIS_AUTH_TOKEN_KEY",
         "AWS_REGION",
@@ -59,6 +61,29 @@ def _forbid_boto3(monkeypatch):
         raise AssertionError("Unexpected boto3.client() call")
 
     monkeypatch.setattr(aws_secrets.boto3, "client", _explode)
+
+
+@pytest.fixture
+def no_verify(monkeypatch):
+    """Skip the eager Redis PING so store-resolution tests need no live Redis."""
+    monkeypatch.setattr(server, "_verify_redis_connection", lambda store: None)
+
+
+@pytest.fixture
+def capture_log(caplog):
+    """Capture records from a fastmcp-namespaced logger.
+
+    The ``fastmcp`` logger sets ``propagate=False``, so caplog's root handler
+    never sees these records — attach it directly to the target logger instead.
+    """
+
+    def _capture(logger_name: str):
+        target = logging.getLogger(logger_name)
+        target.addHandler(caplog.handler)
+        target.setLevel(logging.WARNING)
+        return caplog
+
+    return _capture
 
 
 def test_get_secret_caches_within_ttl(monkeypatch):
@@ -101,10 +126,10 @@ def test_parse_default_ttl_unset(monkeypatch):
     assert aws_secrets._parse_default_ttl() == 300
 
 
-def test_parse_default_ttl_invalid_falls_back(monkeypatch, caplog):
+def test_parse_default_ttl_invalid_falls_back(monkeypatch, capture_log):
+    caplog = capture_log("fastmcp.plane_mcp.aws_secrets")
     monkeypatch.setenv("AWS_SECRET_CACHE_TTL", "not-a-number")
-    with caplog.at_level("WARNING", logger="plane_mcp.aws_secrets"):
-        assert aws_secrets._parse_default_ttl() == 300
+    assert aws_secrets._parse_default_ttl() == 300
     assert any("not an integer" in rec.message for rec in caplog.records)
 
 
@@ -179,14 +204,14 @@ def test_build_token_store_no_env_returns_memory_store():
     assert isinstance(_build_token_store(), MemoryStore)
 
 
-def test_build_token_store_host_port_only_returns_redis(monkeypatch):
+def test_build_token_store_host_port_only_returns_redis(monkeypatch, no_verify):
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     _forbid_boto3(monkeypatch)
     assert isinstance(_build_token_store(), RedisStore)
 
 
-def test_build_token_store_password_wins_over_arn(monkeypatch):
+def test_build_token_store_password_wins_over_arn(monkeypatch, no_verify):
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     monkeypatch.setenv("REDIS_PASSWORD", "pw")
@@ -209,20 +234,20 @@ def test_build_token_store_arn_without_host_port_raises(monkeypatch):
         _build_token_store()
 
 
-def test_build_token_store_arn_without_irsa_skips_sm(monkeypatch, caplog):
+def test_build_token_store_arn_without_irsa_skips_sm(monkeypatch, capture_log, no_verify):
+    caplog = capture_log("fastmcp.plane_mcp.server")
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
     _forbid_boto3(monkeypatch)
 
-    with caplog.at_level("WARNING", logger="plane_mcp.server"):
-        store = _build_token_store()
+    store = _build_token_store()
 
     assert isinstance(store, RedisStore)
     assert any("IRSA/Pod Identity" in rec.message for rec in caplog.records)
 
 
-def test_build_token_store_arn_with_aws_role_arn_activates_sm(monkeypatch):
+def test_build_token_store_arn_with_aws_role_arn_activates_sm(monkeypatch, no_verify):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
@@ -232,7 +257,7 @@ def test_build_token_store_arn_with_aws_role_arn_activates_sm(monkeypatch):
     stubber.assert_no_pending_responses()
 
 
-def test_build_token_store_arn_with_pod_identity_activates_sm(monkeypatch):
+def test_build_token_store_arn_with_pod_identity_activates_sm(monkeypatch, no_verify):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
@@ -252,7 +277,7 @@ def test_build_token_store_arn_missing_token_key_raises(monkeypatch):
         _build_token_store()
 
 
-def test_build_token_store_custom_token_key(monkeypatch):
+def test_build_token_store_custom_token_key(monkeypatch, no_verify):
     monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
     monkeypatch.setenv("REDIS_HOST", "localhost")
     monkeypatch.setenv("REDIS_PORT", "6379")
@@ -260,3 +285,88 @@ def test_build_token_store_custom_token_key(monkeypatch):
     monkeypatch.setenv("REDIS_AUTH_TOKEN_KEY", "token")
     _stub_secrets(monkeypatch, [{"token": "secret-pw"}])
     assert isinstance(_build_token_store(), RedisStore)
+
+
+def _capture_async_redis_kwargs(monkeypatch) -> dict:
+    """Patch redis.asyncio.Redis to record the kwargs the secret path builds it with."""
+    import redis.asyncio as aioredis
+
+    captured: dict = {}
+
+    class _FakeAsyncRedis:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(aioredis, "Redis", _FakeAsyncRedis)
+    return captured
+
+
+def test_build_token_store_secret_path_uses_tls_by_default(monkeypatch, no_verify):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
+    captured = _capture_async_redis_kwargs(monkeypatch)
+
+    _build_token_store()
+    assert captured["ssl"] is True
+
+
+def test_build_token_store_secret_path_ssl_can_be_disabled(monkeypatch, no_verify):
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    monkeypatch.setenv("REDIS_SSL", "false")
+    _stub_secrets(monkeypatch, [{"authToken": "secret-pw"}])
+    captured = _capture_async_redis_kwargs(monkeypatch)
+
+    _build_token_store()
+    assert captured["ssl"] is False
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, True),
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+    ],
+)
+def test_redis_ssl_enabled(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv("REDIS_SSL", raising=False)
+    else:
+        monkeypatch.setenv("REDIS_SSL", value)
+    assert server._redis_ssl_enabled() is expected
+
+
+def test_verify_redis_connection_succeeds():
+    class _Client:
+        async def ping(self):
+            return True
+
+    class _Store:
+        _client = _Client()
+
+    server._verify_redis_connection(_Store())  # should not raise
+
+
+def test_verify_redis_connection_raises_on_failure():
+    class _Client:
+        async def ping(self):
+            raise OSError("connection refused")
+
+    class _Store:
+        _client = _Client()
+
+    with pytest.raises(RuntimeError, match="Redis connection failed during startup PING"):
+        server._verify_redis_connection(_Store())

--- a/tests/test_aws_secrets.py
+++ b/tests/test_aws_secrets.py
@@ -1,6 +1,7 @@
 """Unit tests for plane_mcp.aws_secrets and the Redis token-store resolver."""
 
 import json
+import time
 
 import boto3
 import pytest
@@ -88,6 +89,71 @@ def test_get_secret_returns_copy(monkeypatch):
     first["authToken"] = "mutated"
     second = get_secret(ARN, REGION)
     assert second["authToken"] == "p1"
+
+
+def test_parse_default_ttl_valid(monkeypatch):
+    monkeypatch.setenv("AWS_SECRET_CACHE_TTL", "60")
+    assert aws_secrets._parse_default_ttl() == 60
+
+
+def test_parse_default_ttl_unset(monkeypatch):
+    monkeypatch.delenv("AWS_SECRET_CACHE_TTL", raising=False)
+    assert aws_secrets._parse_default_ttl() == 300
+
+
+def test_parse_default_ttl_invalid_falls_back(monkeypatch, caplog):
+    monkeypatch.setenv("AWS_SECRET_CACHE_TTL", "not-a-number")
+    with caplog.at_level("WARNING", logger="plane_mcp.aws_secrets"):
+        assert aws_secrets._parse_default_ttl() == 300
+    assert any("not an integer" in rec.message for rec in caplog.records)
+
+
+def test_get_secret_concurrent_race_uses_existing_fresh_entry(monkeypatch):
+    """If another thread populates the cache while we're fetching, prefer the
+    existing fresh entry rather than overwriting it."""
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "ours"}])
+
+    # Simulate a racing thread that wrote a fresh entry while our fetch was in
+    # flight, by pre-populating the cache after we've passed the fast-path check
+    # but before the write-back. We do that by patching json.loads to inject.
+    original_loads = aws_secrets.json.loads
+
+    def _injecting_loads(s):
+        # Another thread "won" the race and wrote first.
+        aws_secrets._SECRET_CACHE[(ARN, REGION)] = {
+            "value": {"authToken": "theirs"},
+            "fetched_at": time.time(),
+        }
+        return original_loads(s)
+
+    monkeypatch.setattr(aws_secrets.json, "loads", _injecting_loads)
+
+    result = get_secret(ARN, REGION)
+    assert result == {"authToken": "theirs"}
+    assert aws_secrets._SECRET_CACHE[(ARN, REGION)]["value"] == {"authToken": "theirs"}
+    stubber.assert_no_pending_responses()
+
+
+def test_get_secret_force_refresh_overwrites_race_winner(monkeypatch):
+    """force_refresh=True always installs the freshly-fetched value, ignoring
+    any racing writer."""
+    stubber = _stub_secrets(monkeypatch, [{"authToken": "forced"}])
+
+    original_loads = aws_secrets.json.loads
+
+    def _injecting_loads(s):
+        aws_secrets._SECRET_CACHE[(ARN, REGION)] = {
+            "value": {"authToken": "stale-racer"},
+            "fetched_at": time.time(),
+        }
+        return original_loads(s)
+
+    monkeypatch.setattr(aws_secrets.json, "loads", _injecting_loads)
+
+    result = get_secret(ARN, REGION, force_refresh=True)
+    assert result == {"authToken": "forced"}
+    assert aws_secrets._SECRET_CACHE[(ARN, REGION)]["value"] == {"authToken": "forced"}
+    stubber.assert_no_pending_responses()
 
 
 def test_credential_provider_returns_password(monkeypatch):


### PR DESCRIPTION
## What & why

Adds support for sourcing the Redis/ElastiCache auth token from **AWS Secrets Manager** (for rotated ElastiCache AUTH tokens), and makes the token-store path observable and fail-loud.

### Secrets Manager integration
- `plane_mcp/aws_secrets.py`:
  - `get_secret()` — TTL-cached (`AWS_SECRET_CACHE_TTL`, default 300s) fetch from Secrets Manager, keyed by `(arn, region)`, with safe concurrent refresh and defensive copying.
  - `ElastiCacheCredentialProvider` — a redis-py `CredentialProvider` that resolves the current password on every new connection, so rotated tokens are picked up without a restart.
- `_build_token_store()` selects the backend in priority order:
  1. `REDIS_PASSWORD` → Redis with static password
  2. `ELASTICACHE_SECRET_ARN` **+** IRSA/Pod-Identity creds → Redis with Secrets-Manager-backed auth
  3. `REDIS_HOST`/`REDIS_PORT` only → plain Redis
  4. nothing → in-memory fallback (with a warning)

  Misconfigurations (`REDIS_PASSWORD`/`ELASTICACHE_SECRET_ARN` set without host/port, or a missing token key in the secret) raise rather than degrade silently.

### Fixes uncovered while validating against a live ElastiCache cluster
- **Logging was invisible.** `server.py`/`aws_secrets.py` logged via the stdlib `plane_mcp.*` namespace, which `configure_json_logging()` never attaches a handler to — so every `INFO` line (`"Using Redis..."`, `"Refreshed secret..."`) was dropped. Switched both to fastmcp's `get_logger`, nesting them under the configured `fastmcp` logger.
- **TLS was missing.** ElastiCache requires in-transit encryption whenever Redis AUTH tokens are used, but the client was built without it, so the connection failed against a TLS-enabled cluster. Added `ssl`, defaulting **on** for this path (`REDIS_SSL=false` to opt out for a plaintext self-managed Redis).
- **Lazy connect hid failures.** `RedisStore` connects on first use, so a bad config looked healthy until the first OAuth flow. Added an eager `PING` at startup that raises a clear `RuntimeError` instead of silently degrading.

## New environment variables

| Variable | Default | Purpose |
|---|---|---|
| `ELASTICACHE_SECRET_ARN` | — | Secrets Manager ARN holding the Redis auth token |
| `REDIS_AUTH_TOKEN_KEY` | `authToken` | JSON key within the secret |
| `AWS_REGION` | `us-east-1` | Region for the Secrets Manager client |
| `AWS_SECRET_CACHE_TTL` | `300` | Secret cache TTL (seconds) |
| `REDIS_SSL` | `true` | TLS for the ElastiCache path |

Requires IRSA (`AWS_ROLE_ARN`) or EKS Pod Identity (`AWS_CONTAINER_CREDENTIALS_FULL_URI`) for the Secrets Manager path to activate.

## Testing
- `tests/test_aws_secrets.py`: secret caching, TTL/refresh, concurrent-race handling, credential provider, token-store selection across all four paths, the TLS default + override, and the eager-PING fail-loud behavior. 36 tests, all passing.

## Dependencies
- Added `boto3` for Secrets Manager.
- Pinned `fakeredis[lua]>=2.32.1,<2.35.0` (newer fakeredis removed `FakeConnection` from `fakeredis.aioredis`, which pydocket imports).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS Secrets Manager support for Redis auth with TTL-cached secrets, safe concurrent refreshes, and defensive copies
  * ElastiCache credential provider that yields password-only or username+password credentials
  * Token-store selection that prefers Redis (with password), supports Secrets Manager–backed auth, verifies connectivity, and falls back to in-memory store with warnings

* **Chores**
  * Add AWS SDK and fakeredis compatibility dependency updates

* **Tests**
  * Expanded tests for secret caching, TTL/refresh, credential provider, SSL handling, and token-store selection

* **Documentation**
  * Expanded test environment template with Redis/Secrets Manager configuration guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->