### PR TITLE
feat: include authenticated user-id on every JSON log line

### DIFF
--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -9,11 +9,36 @@ from datetime import datetime, timezone
 from enum import Enum
 
 import uvicorn
+from fastmcp.server.dependencies import get_access_token
 from starlette.applications import Starlette
 from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
 
 from plane_mcp.server import get_header_mcp, get_oauth_mcp, get_stdio_mcp
+
+
+class UserContextFilter(logging.Filter):
+    """Attach the authenticated user's id/display_name to every log record.
+
+    Pulls the current request's access token via FastMCP's dependency, which
+    returns None (never raises) outside a request context — so startup logs and
+    stdio mode simply carry no user info.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        user_id = None
+        display_name = None
+        try:
+            token = get_access_token()
+            if token:
+                user_id = token.claims.get("sub")
+                display_name = token.claims.get("display_name")
+        except Exception:
+            # Never let logging enrichment break a request.
+            pass
+        record.user_id = user_id
+        record.display_name = display_name
+        return True
 
 
 class JSONFormatter(logging.Formatter):
@@ -26,6 +51,12 @@ class JSONFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
+        user_id = getattr(record, "user_id", None)
+        if user_id:
+            log_entry["user_id"] = user_id
+        display_name = getattr(record, "display_name", None)
+        if display_name:
+            log_entry["display_name"] = display_name
         if record.exc_info and record.exc_info[1]:
             log_entry["error"] = {
                 "type": type(record.exc_info[1]).__name__,
@@ -44,6 +75,7 @@ def configure_json_logging():
 
     handler = logging.StreamHandler(sys.stderr)
     handler.setFormatter(JSONFormatter())
+    handler.addFilter(UserContextFilter())
     fastmcp_logger.addHandler(handler)
     fastmcp_logger.setLevel(logging.INFO)
     fastmcp_logger.propagate = False
@@ -87,7 +119,6 @@ def main() -> None:
         return
 
     if server_mode == ServerMode.HTTP:
-
         prefix = os.getenv("MCP_PATH_PREFIX") or ""
 
         oauth_mcp = get_oauth_mcp(prefix + "/http")
@@ -131,6 +162,7 @@ def main() -> None:
                 uv_logger.removeHandler(h)
             uv_handler = logging.StreamHandler(sys.stderr)
             uv_handler.setFormatter(JSONFormatter())
+            uv_handler.addFilter(UserContextFilter())
             uv_logger.addHandler(uv_handler)
 
         logger.info("Starting HTTP server at URLs: /mcp and /header/mcp")

--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -33,9 +33,9 @@ class UserContextFilter(logging.Filter):
             if token:
                 user_id = token.claims.get("sub")
                 display_name = token.claims.get("display_name")
-        except Exception:
-            # Never let logging enrichment break a request.
-            pass
+        except Exception as exc:
+            # Never let logging enrichment break a request, but leave a signal.
+            record.user_context_enrichment_error = type(exc).__name__
         record.user_id = user_id
         record.display_name = display_name
         return True
@@ -57,6 +57,9 @@ class JSONFormatter(logging.Formatter):
         display_name = getattr(record, "display_name", None)
         if display_name:
             log_entry["display_name"] = display_name
+        err = getattr(record, "user_context_enrichment_error", None)
+        if err:
+            log_entry["user_context_enrichment_error"] = err
         if record.exc_info and record.exc_info[1]:
             log_entry["error"] = {
                 "type": type(record.exc_info[1]).__name__,


### PR DESCRIPTION
## Problem

Today the user id and the request/response logs land on **separate lines**:

```
... "message": "User: (b3fea12b-...) - goutham.pratapa"}   <- OAuth provider, once per auth
... "message": "{\"event\": \"request_start\", ...}"        <- StructuredLoggingMiddleware
... "message": "{\"event\": \"request_success\", ...}"
```

There's no way to correlate a `request_start`/`request_success` line with the user that made the request.

## Change

All in `plane_mcp/__main__.py`:

- **`UserContextFilter`** — a logging filter that calls FastMCP's `get_access_token()` and stamps `user_id` (`claims["sub"]`) and `display_name` onto each `LogRecord`. `get_access_token()` returns `None` (never raises) outside a request context, so startup logs and stdio mode carry no user info. Wrapped in `try/except` defensively.
- **`JSONFormatter`** — emits `user_id`/`display_name` only when present, keeping non-request lines clean.
- Filter attached to both the `fastmcp` handler and the uvicorn handlers.

Because the filter sits on the shared handler, it enriches **all** records — including FastMCP's built-in middleware lines — without subclassing or forking FastMCP.

Resulting line:

```json
{..., "logger": "fastmcp.middleware.structured_logging",
 "message": "{\"event\": \"request_success\", ...}",
 "user_id": "b3fea12b-4c99-4b8f-b726-6121c79f12aa",
 "display_name": "goutham.pratapa"}
```

## Testing

- `ruff check`/`format` pass on the changed file (pre-existing E501s elsewhere untouched).
- Verified the filter+formatter: no-context records stay as-is; user-context records gain `user_id`/`display_name`.
- To verify live: run `python -m plane_mcp http`, call a tool with an OAuth token, and confirm `request_*` lines now carry `user_id` matching the `User: (...)` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Server JSON logs now include authenticated user context (user ID and display name) when available to improve auditing and debugging.
  * If enrichment fails, logs record an enrichment error field so failures are visible without raising errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->