### PR TITLE
chore: add configurable CIMD support for Plane OAuth provider

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -14,6 +14,7 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # PLANE_OAUTH_PROVIDER_CLIENT_ID=your_oauth_client_id
 # PLANE_OAUTH_PROVIDER_CLIENT_SECRET=your_oauth_client_secret
 # PLANE_OAUTH_PROVIDER_BASE_URL=http://localhost:8211
+# PLANE_OAUTH_PROVIDER_ENABLE_CIMD=false  # Set to true to enable Client-Initiated Message Delivery
 
 # Optional: Route prefix — prepended to all mounted routes.
 # Use when reverse-proxying alongside other apps.

--- a/.env.test
+++ b/.env.test
@@ -14,7 +14,7 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # PLANE_OAUTH_PROVIDER_CLIENT_ID=your_oauth_client_id
 # PLANE_OAUTH_PROVIDER_CLIENT_SECRET=your_oauth_client_secret
 # PLANE_OAUTH_PROVIDER_BASE_URL=http://localhost:8211
-# PLANE_OAUTH_PROVIDER_ENABLE_CIMD=false  # Set to true to enable Client-Initiated Message Delivery
+# PLANE_OAUTH_PROVIDER_ENABLE_CIMD=false  # Set to true to enable client-id-metadata-document support
 
 # Optional: Route prefix — prepended to all mounted routes.
 # Use when reverse-proxying alongside other apps.

--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -351,6 +351,7 @@ class PlaneOAuthProvider(OAuthProxy):
             jwt_signing_key=settings.jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             valid_scopes=["read", "write"],
+            enable_cimd=False,
         )
 
         logger.info(

--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -91,6 +91,7 @@ class PlaneOAuthProviderSettings(BaseSettings):
     jwt_signing_key: str | None = None
     plane_base_url: str | None = None
     plane_internal_base_url: str | None = None  # Internal URL for server-to-server calls
+    enable_cimd: bool | None = None
 
     @field_validator("required_scopes", mode="before")
     @classmethod
@@ -248,6 +249,7 @@ class PlaneOAuthProvider(OAuthProxy):
         require_authorization_consent: bool = True,
         plane_base_url: str | NotSetT = NotSet,
         plane_internal_base_url: str | NotSetT = NotSet,
+        enable_cimd: bool | NotSetT = NotSet,
     ):
         """Initialize Plane OAuth provider.
 
@@ -285,6 +287,8 @@ class PlaneOAuthProvider(OAuthProxy):
                 testing environments.
             plane_base_url: Base URL for Plane API
                 (defaults to https://api.plane.so or PLANE_BASE_URL env var)
+            enable_cimd: Whether to enable CIMD (Client ID Metadata Document) support.
+                Defaults to False. Can be set via the PLANE_OAUTH_PROVIDER_ENABLE_CIMD environment variable.
         """
 
         settings = PlaneOAuthProviderSettings.model_validate(
@@ -302,6 +306,7 @@ class PlaneOAuthProvider(OAuthProxy):
                     "jwt_signing_key": jwt_signing_key,
                     "plane_base_url": plane_base_url,
                     "plane_internal_base_url": plane_internal_base_url,
+                    "enable_cimd": enable_cimd,
                 }.items()
                 if v is not NotSet
             }
@@ -323,6 +328,7 @@ class PlaneOAuthProvider(OAuthProxy):
         plane_internal_url = (
             settings.plane_internal_base_url or os.getenv("PLANE_INTERNAL_BASE_URL") or plane_base_url_final
         )
+        enable_cimd_final = settings.enable_cimd if settings.enable_cimd is not None else False
 
         # Create Plane token verifier (uses internal URL for server-to-server calls)
         token_verifier = PlaneOAuthTokenVerifier(
@@ -351,7 +357,7 @@ class PlaneOAuthProvider(OAuthProxy):
             jwt_signing_key=settings.jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             valid_scopes=["read", "write"],
-            enable_cimd=False,
+            enable_cimd=enable_cimd_final,
         )
 
         logger.info(

--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -91,7 +91,7 @@ class PlaneOAuthProviderSettings(BaseSettings):
     jwt_signing_key: str | None = None
     plane_base_url: str | None = None
     plane_internal_base_url: str | None = None  # Internal URL for server-to-server calls
-    enable_cimd: bool | None = None
+    enable_cimd: bool = False
 
     @field_validator("required_scopes", mode="before")
     @classmethod
@@ -328,7 +328,6 @@ class PlaneOAuthProvider(OAuthProxy):
         plane_internal_url = (
             settings.plane_internal_base_url or os.getenv("PLANE_INTERNAL_BASE_URL") or plane_base_url_final
         )
-        enable_cimd_final = settings.enable_cimd if settings.enable_cimd is not None else False
 
         # Create Plane token verifier (uses internal URL for server-to-server calls)
         token_verifier = PlaneOAuthTokenVerifier(
@@ -357,7 +356,7 @@ class PlaneOAuthProvider(OAuthProxy):
             jwt_signing_key=settings.jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
             valid_scopes=["read", "write"],
-            enable_cimd=enable_cimd_final,
+            enable_cimd=settings.enable_cimd,
         )
 
         logger.info(

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -25,6 +25,7 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
             base_url=f"{os.getenv('PLANE_OAUTH_PROVIDER_BASE_URL')}{base_path}",
             plane_base_url=os.getenv("PLANE_BASE_URL", ""),
             plane_internal_base_url=os.getenv("PLANE_INTERNAL_BASE_URL", ""),
+            enable_cimd=os.getenv("PLANE_OAUTH_PROVIDER_ENABLE_CIMD", "false").lower() == "true",
             client_storage=build_token_store(),
             required_scopes=["read", "write"],
             allowed_client_redirect_uris=[

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -40,6 +40,8 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
                 "vscode-insiders://*",
                 "windsurf://*",
                 "claude://*",
+                # Claude.ai web client
+                "https://claude.ai/*",
             ],
         ),
     )


### PR DESCRIPTION
### Description
Adds a configurable `enable_cimd` option to the Plane OAuth provider and exposes it via the `PLANE_OAUTH_PROVIDER_ENABLE_CIMD` environment variable. CIMD remains disabled by default and can be explicitly enabled when needed.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Improvement (change that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Performance improvements
- [x] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to enable CIMD support in the OAuth provider (toggle via settings or environment).
  * Allowed the Claude.ai web client redirect origin/path in OAuth redirect URIs.

* **Chores**
  * Added a commented test configuration entry showing how to enable the CIMD toggle for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->