### PR TITLE
fix: drop display_name from logs to avoid logging PII

### DIFF
--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -18,26 +18,24 @@ from plane_mcp.server import get_header_mcp, get_oauth_mcp, get_stdio_mcp
 
 
 class UserContextFilter(logging.Filter):
-    """Attach the authenticated user's id/display_name to every log record.
+    """Attach the authenticated user's id to every log record.
 
     Pulls the current request's access token via FastMCP's dependency, which
     returns None (never raises) outside a request context — so startup logs and
-    stdio mode simply carry no user info.
+    stdio mode simply carry no user info. Only the opaque user id is recorded;
+    PII such as the display name / email is intentionally never logged.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
         user_id = None
-        display_name = None
         try:
             token = get_access_token()
             if token:
                 user_id = token.claims.get("sub")
-                display_name = token.claims.get("display_name")
         except Exception as exc:
             # Never let logging enrichment break a request, but leave a signal.
             record.user_context_enrichment_error = type(exc).__name__
         record.user_id = user_id
-        record.display_name = display_name
         return True
 
 
@@ -54,9 +52,6 @@ class JSONFormatter(logging.Formatter):
         user_id = getattr(record, "user_id", None)
         if user_id:
             log_entry["user_id"] = user_id
-        display_name = getattr(record, "display_name", None)
-        if display_name:
-            log_entry["display_name"] = display_name
         err = getattr(record, "user_context_enrichment_error", None)
         if err:
             log_entry["user_context_enrichment_error"] = err


### PR DESCRIPTION
## Problem

PR #142 added `user_id` **and** `display_name` to every JSON log line. The display name is PII — logging it on every request risks violating privacy rules.

## Change

In `plane_mcp/__main__.py`, stop collecting and emitting `display_name`:

- `UserContextFilter` now records only `user_id` (`claims["sub"]`, an opaque UUID).
- `JSONFormatter` no longer emits a `display_name` key.
- Docstring updated to note PII (display name / email) is intentionally never logged.

The `user_id` UUID is sufficient to correlate a request with its user without exposing personal data. The enrichment-error signal added previously is unchanged.

## Result

```json
{..., "logger": "fastmcp.middleware.structured_logging",
 "message": "{\"event\": \"request_success\", ...}",
 "user_id": "b3fea12b-4c99-4b8f-b726-6121c79f12aa"}
```

## Testing

- `ruff check` / `format` pass.
- Verified the filter+formatter: with a token whose claims include `display_name`/`email`, the formatted line contains only `user_id` — no PII leaks. No-context lines stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System logs now capture only opaque user identifiers instead of display names and email addresses, enhancing privacy protection and reducing exposure of sensitive user information in log files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->