### PR TITLE
chore: consolidate add/remove and archive/unarchive tool pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,10 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 | `update_cycle` | Update a cycle with partial data |
 | `delete_cycle` | Delete a cycle by ID |
 | `list_archived_cycles` | List archived cycles in a project |
-| `add_work_items_to_cycle` | Add work items to a cycle |
-| `remove_work_item_from_cycle` | Remove a work item from a cycle |
+| `manage_cycle_work_items` | Add and/or remove work items on a cycle |
 | `list_cycle_work_items` | List work items in a cycle |
 | `transfer_cycle_work_items` | Transfer work items from one cycle to another |
-| `archive_cycle` | Archive a cycle |
-| `unarchive_cycle` | Unarchive a cycle |
+| `manage_cycle_archive` | Archive or unarchive a cycle |
 
 ### Modules
 
@@ -186,11 +184,9 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 | `update_module` | Update a module with partial data |
 | `delete_module` | Delete a module by ID |
 | `list_archived_modules` | List archived modules in a project |
-| `add_work_items_to_module` | Add work items to a module |
-| `remove_work_item_from_module` | Remove a work item from a module |
+| `manage_module_work_items` | Add and/or remove work items on a module |
 | `list_module_work_items` | List work items in a module |
-| `archive_module` | Archive a module |
-| `unarchive_module` | Unarchive a module |
+| `manage_module_archive` | Archive or unarchive a module |
 
 ### Initiatives
 
@@ -231,8 +227,7 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 | `retrieve_milestone` | Retrieve a milestone by ID |
 | `update_milestone` | Update a milestone by ID |
 | `delete_milestone` | Delete a milestone by ID |
-| `add_work_items_to_milestone` | Add work items to a milestone |
-| `remove_work_items_from_milestone` | Remove work items from a milestone |
+| `manage_milestone_work_items` | Add and/or remove work items on a milestone |
 | `list_milestone_work_items` | List work items in a milestone |
 
 ### Labels
@@ -317,8 +312,7 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 |-----------|-------------|
 | `retrieve_workspace_page` | Retrieve a workspace page by ID |
 | `retrieve_project_page` | Retrieve a project page by ID |
-| `create_workspace_page` | Create a workspace page |
-| `create_project_page` | Create a project page |
+| `create_page` | Create a workspace or project page |
 
 ### Workspaces
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 | `delete_project` | Delete a project by ID |
 | `get_project_worklog_summary` | Get work log summary for a project |
 | `get_project_members` | Get all members of a project |
-| `get_project_features` | Get features configuration of a project |
 | `update_project_features` | Update features configuration of a project |
 
 ### Work Items
@@ -163,12 +162,11 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 
 | Tool Name | Description |
 |-----------|-------------|
-| `list_cycles` | List all cycles in a project |
+| `list_cycles` | List cycles in a project (set `archived=true` for archived) |
 | `create_cycle` | Create a new cycle with name, dates, and owner |
 | `retrieve_cycle` | Retrieve a cycle by ID |
 | `update_cycle` | Update a cycle with partial data |
 | `delete_cycle` | Delete a cycle by ID |
-| `list_archived_cycles` | List archived cycles in a project |
 | `manage_cycle_work_items` | Add and/or remove work items on a cycle |
 | `list_cycle_work_items` | List work items in a cycle |
 | `transfer_cycle_work_items` | Transfer work items from one cycle to another |
@@ -178,12 +176,11 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 
 | Tool Name | Description |
 |-----------|-------------|
-| `list_modules` | List all modules in a project |
+| `list_modules` | List modules in a project (set `archived=true` for archived) |
 | `create_module` | Create a new module with name, dates, status, and members |
 | `retrieve_module` | Retrieve a module by ID |
 | `update_module` | Update a module with partial data |
 | `delete_module` | Delete a module by ID |
-| `list_archived_modules` | List archived modules in a project |
 | `manage_module_work_items` | Add and/or remove work items on a module |
 | `list_module_work_items` | List work items in a module |
 | `manage_module_archive` | Archive or unarchive a module |
@@ -310,8 +307,8 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 
 | Tool Name | Description |
 |-----------|-------------|
-| `retrieve_workspace_page` | Retrieve a workspace page by ID |
-| `retrieve_project_page` | Retrieve a project page by ID |
+| `list_pages` | List pages (workspace, or a project's if `project_id` given) |
+| `retrieve_page` | Retrieve a page by ID (workspace, or project's if `project_id` given) |
 | `create_page` | Create a workspace or project page |
 
 ### Workspaces
@@ -319,7 +316,7 @@ The server provides comprehensive tools for interacting with Plane. All tools us
 | Tool Name | Description |
 |-----------|-------------|
 | `get_workspace_members` | Get all members of the current workspace |
-| `get_workspace_features` | Get features of the current workspace |
+| `get_features` | Get feature flags (workspace, or a project's if `project_id` given) |
 | `update_workspace_features` | Update features of the current workspace |
 
 ### Users

--- a/plane_mcp/instructions.py
+++ b/plane_mcp/instructions.py
@@ -1,45 +1,15 @@
 """Server-level instructions sent once to MCP clients (FastMCP `instructions` param)."""
 
-WORK_ITEM_TYPE_SCOPING_INSTRUCTIONS = """
-## Work item type scoping
-
-To get a usable work item type for a project (e.g. "Epic", "Initiative"), call resolve_work_item_type(project_id, name). It returns the type (its id is the type_id for create_work_item) and handles everything in one step:
-- If the workspace owns work item types, it finds or creates the type at the workspace level and imports it into the project (project-level creation is not allowed in this mode).
-- Otherwise it finds or creates the type at the project level, enabling the project's work item types feature first if needed.
-
-Prefer this single tool over manually combining get_workspace_features, list_work_item_types, create_work_item_type, and import_work_item_types_to_project — it does all of that deterministically and never creates a duplicate.
-"""
-
-EPIC_INSTRUCTIONS = """
+SERVER_INSTRUCTIONS = """
 ## Epics
 
-This server has no dedicated epic tools (no create_epic, list_epics, retrieve_epic, update_epic, delete_epic, list_epic_issues, add_epic_issues). An "epic" is just a work item whose work item type is named "Epic".
-
-1. type = resolve_work_item_type(project_id, "Epic") — see "Work item type scoping".
-2. Create: create_work_item(project_id=project_id, type_id=type.id, name=<epic name>).
-3. List epics: list_work_items(project_id=project_id, pql='type = "<type id>"') (or pql='isEpic()').
-4. Read, update, or delete: retrieve_work_item / update_work_item / delete_work_item, using the epic's work item id.
-5. Nest a work item under an epic: create_work_item or update_work_item with parent=<epic work item id>.
-6. List an epic's children: list_work_items(project_id=project_id, pql='childOf("<EPIC-IDENTIFIER>")'), where <EPIC-IDENTIFIER> is the epic's human-readable identifier (e.g. "PROJ-12") from retrieve_work_item.
+There are no epic tools — an epic is a work item whose type is named "Epic". Work
+items always belong to a project; ask which if one is not named.
+1. type = resolve_work_item_type(project_id, "Epic") — type.id is the type_id.
+2. Create: create_work_item(project_id, type_id=type.id, name=...).
+3. List: list_work_items(project_id, pql='type = "<type id>"').
+4. Read / update / delete / nest: retrieve_work_item / update_work_item /
+   delete_work_item by work item id (set parent=<work item id> to nest).
+5. List an epic's children: list_work_items(project_id, pql='childOf("<EPIC-IDENTIFIER>")')
+   using the epic's human-readable identifier (e.g. "PROJ-12") from retrieve_work_item.
 """
-
-INITIATIVE_INSTRUCTIONS = """
-## Initiatives
-
-Call get_workspace_features() first. Pick exactly one path — never mix them.
-
-If initiatives is true — native workspace-level objects (no project_id needed):
-- Create: create_initiative(name=...).
-- List: list_initiatives().
-- Read/update/delete: retrieve_initiative / update_initiative / delete_initiative by initiative id.
-
-If initiatives is false — fall back to an "Initiative" work item type inside a project:
-1. If the user has not named a project, ask which project to use before proceeding.
-2. type = resolve_work_item_type(project_id, "Initiative") — handles everything: checks if the type is already in the project, finds or creates it at the workspace level if workspace owns types (the common case — "Initiative" is normally a workspace-level type imported into projects), or creates it at the project level if the project owns its own types. Never creates a duplicate.
-3. Create: create_work_item(project_id=project_id, type_id=type.id, name=<initiative name>).
-4. List: list_work_items(project_id=project_id, pql='type = "<type id>"').
-5. Read/update/delete: retrieve_work_item / update_work_item / delete_work_item by work item id.
-Use this fallback only when initiatives is false.
-"""
-
-SERVER_INSTRUCTIONS = WORK_ITEM_TYPE_SCOPING_INSTRUCTIONS + EPIC_INSTRUCTIONS + INITIATIVE_INSTRUCTIONS

--- a/plane_mcp/tools/cycles.py
+++ b/plane_mcp/tools/cycles.py
@@ -211,6 +211,8 @@ def register_cycle_tools(mcp: FastMCP) -> None:
             add_ids: UUIDs of work items to add to the cycle
             remove_ids: UUIDs of work items to remove from the cycle
         """
+        if not add_ids and not remove_ids:
+            raise ValueError("At least one of add_ids or remove_ids must be provided.")
         client, workspace_slug = get_plane_client_context()
         if add_ids:
             client.cycles.add_work_items(

--- a/plane_mcp/tools/cycles.py
+++ b/plane_mcp/tools/cycles.py
@@ -194,49 +194,39 @@ def register_cycle_tools(mcp: FastMCP) -> None:
         return response.results
 
     @mcp.tool()
-    def add_work_items_to_cycle(
+    def manage_cycle_work_items(
         project_id: str,
         cycle_id: str,
-        work_item_ids: list[str],
+        add_ids: list[str] | None = None,
+        remove_ids: list[str] | None = None,
     ) -> None:
         """
-        Add work items to a cycle.
+        Add or remove work items on a cycle in a single call.
+
+        At least one of add_ids or remove_ids must be provided.
 
         Args:
             project_id: UUID of the project
             cycle_id: UUID of the cycle
-            work_item_ids: List of work item UUIDs to add to the cycle
+            add_ids: UUIDs of work items to add to the cycle
+            remove_ids: UUIDs of work items to remove from the cycle
         """
         client, workspace_slug = get_plane_client_context()
-        client.cycles.add_work_items(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            cycle_id=cycle_id,
-            issue_ids=work_item_ids,
-        )
-
-    @mcp.tool()
-    def remove_work_item_from_cycle(
-        project_id: str,
-        cycle_id: str,
-        work_item_id: str,
-    ) -> None:
-        """
-        Remove a work item from a cycle.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-            cycle_id: UUID of the cycle
-            work_item_id: UUID of the work item to remove
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.cycles.remove_work_item(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            cycle_id=cycle_id,
-            work_item_id=work_item_id,
-        )
+        if add_ids:
+            client.cycles.add_work_items(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                cycle_id=cycle_id,
+                issue_ids=add_ids,
+            )
+        if remove_ids:
+            for work_item_id in remove_ids:
+                client.cycles.remove_work_item(
+                    workspace_slug=workspace_slug,
+                    project_id=project_id,
+                    cycle_id=cycle_id,
+                    work_item_id=work_item_id,
+                )
 
     @mcp.tool()
     def list_cycle_work_items(
@@ -329,24 +319,28 @@ def register_cycle_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool()
-    def archive_cycle(project_id: str, cycle_id: str) -> bool:
+    def manage_cycle_archive(project_id: str, cycle_id: str, archive: bool) -> bool:
         """
-        Archive a cycle.
+        Archive or unarchive a cycle.
 
         Plane requires the cycle end_date to be in the past before archiving.
-        This tool automatically sets end_date to today if the cycle is still
-        active (end_date is missing or in the future), then archives it.
+        When archive=True, this tool automatically sets end_date to today if
+        the cycle is still active (end_date is missing or in the future),
+        then archives it.
 
         Args:
             project_id: UUID of the project
             cycle_id: UUID of the cycle
+            archive: True to archive the cycle, False to unarchive it
 
         Returns:
-            True if the cycle was archived successfully
+            True if the operation completed successfully
         """
         client, workspace_slug = get_plane_client_context()
-        today = date.today().isoformat()
+        if not archive:
+            return client.cycles.unarchive(workspace_slug=workspace_slug, project_id=project_id, cycle_id=cycle_id)
 
+        today = date.today().isoformat()
         cycle = client.cycles.retrieve(workspace_slug=workspace_slug, project_id=project_id, cycle_id=cycle_id)
         end_date = cycle.end_date if hasattr(cycle, "end_date") else None
         if not end_date or end_date > today:
@@ -384,18 +378,3 @@ def register_cycle_tools(mcp: FastMCP) -> None:
             data=UpdateCycle(end_date=today),
         )
 
-    @mcp.tool()
-    def unarchive_cycle(project_id: str, cycle_id: str) -> bool:
-        """
-        Unarchive a cycle.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-            cycle_id: UUID of the cycle
-
-        Returns:
-            True if the cycle was unarchived successfully
-        """
-        client, workspace_slug = get_plane_client_context()
-        return client.cycles.unarchive(workspace_slug=workspace_slug, project_id=project_id, cycle_id=cycle_id)

--- a/plane_mcp/tools/cycles.py
+++ b/plane_mcp/tools/cycles.py
@@ -30,20 +30,26 @@ def register_cycle_tools(mcp: FastMCP) -> None:
     @mcp.tool()
     def list_cycles(
         project_id: str,
+        archived: bool = False,
         params: dict[str, Any] | None = None,
     ) -> list[Cycle]:
         """
-        List all cycles in a project.
+        List cycles in a project.
 
         Args:
-            workspace_slug: The workspace slug identifier
             project_id: UUID of the project
+            archived: Set True to list archived cycles instead of active ones.
             params: Optional query parameters as a dictionary
 
         Returns:
             List of Cycle objects
         """
         client, workspace_slug = get_plane_client_context()
+        if archived:
+            archived_response: PaginatedArchivedCycleResponse = client.cycles.list_archived(
+                workspace_slug=workspace_slug, project_id=project_id, params=params
+            )
+            return archived_response.results
         response: PaginatedCycleResponse = client.cycles.list(
             workspace_slug=workspace_slug, project_id=project_id, params=params
         )
@@ -172,28 +178,6 @@ def register_cycle_tools(mcp: FastMCP) -> None:
         client.cycles.delete(workspace_slug=workspace_slug, project_id=project_id, cycle_id=cycle_id)
 
     @mcp.tool()
-    def list_archived_cycles(
-        project_id: str,
-        params: dict[str, Any] | None = None,
-    ) -> list[Cycle]:
-        """
-        List archived cycles in a project.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-            params: Optional query parameters as a dictionary
-
-        Returns:
-            List of archived Cycle objects
-        """
-        client, workspace_slug = get_plane_client_context()
-        response: PaginatedArchivedCycleResponse = client.cycles.list_archived(
-            workspace_slug=workspace_slug, project_id=project_id, params=params
-        )
-        return response.results
-
-    @mcp.tool()
     def manage_cycle_work_items(
         project_id: str,
         cycle_id: str,
@@ -285,7 +269,9 @@ def register_cycle_tools(mcp: FastMCP) -> None:
                 }
             raise
         return {
-            "results": [item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])],
+            "results": [
+                item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])
+            ],
             "total_count": response.total_count,
             "count": response.count,
             "next_cursor": response.next_cursor,
@@ -379,4 +365,3 @@ def register_cycle_tools(mcp: FastMCP) -> None:
             cycle_id=cycle_id,
             data=UpdateCycle(end_date=today),
         )
-

--- a/plane_mcp/tools/initiatives.py
+++ b/plane_mcp/tools/initiatives.py
@@ -15,6 +15,18 @@ from plane.models.initiatives import (
 from plane_mcp.client import get_plane_client_context
 
 
+def _require_native_initiatives(client: Any, workspace_slug: str, fallback: str) -> None:
+    """Raise a ToolError with fallback guidance when the initiatives feature is off.
+
+    Native initiative endpoints only work when the workspace "initiatives" feature
+    is enabled. When it is off, initiatives are modeled as "Initiative" work items,
+    so every native initiative tool must redirect the caller to the work-item path.
+    """
+    features = client.workspaces.get_features(workspace_slug=workspace_slug)
+    if not features.model_dump().get("initiatives"):
+        raise ToolError(f"The initiatives feature is disabled for this workspace. {fallback}")
+
+
 def register_initiative_tools(mcp: FastMCP) -> None:
     """Register all initiative-related tools with the MCP server."""
 
@@ -30,8 +42,20 @@ def register_initiative_tools(mcp: FastMCP) -> None:
 
         Returns:
             List of Initiative objects
+
+        Raises:
+            ToolError: if the initiatives feature is disabled. When disabled,
+                initiatives are "Initiative" work items — the error gives the steps.
         """
         client, workspace_slug = get_plane_client_context()
+        _require_native_initiatives(
+            client,
+            workspace_slug,
+            'Initiatives are stored as "Initiative" work items here. List them with '
+            'resolve_work_item_type(project_id, "Initiative"), then '
+            "list_work_items(project_id, pql='type = \"<type id>\"'). "
+            "Work items belong to a project — ask which if not named.",
+        )
         response: PaginatedInitiativeResponse = client.initiatives.list(workspace_slug=workspace_slug, params=params)
         return response.results
 
@@ -63,20 +87,19 @@ def register_initiative_tools(mcp: FastMCP) -> None:
         Raises:
             ToolError: if the workspace's initiatives feature is disabled. Native
                 initiatives require the feature to be enabled in workspace settings.
-                When disabled, create an "Initiative" work item instead
-                (see the "Initiatives" server instructions).
+                When disabled, create an "Initiative" work item instead — the error
+                message gives the exact steps.
         """
         client, workspace_slug = get_plane_client_context()
 
-        features = client.workspaces.get_features(workspace_slug=workspace_slug)
-        if not features.model_dump().get("initiatives"):
-            raise ToolError(
-                f"The initiatives feature is disabled for this workspace. "
-                f"Create {repr(name)} as an \"Initiative\" work item instead:\n"
-                f"1. Work items belong to a project — if not named, ask the user which project to use.\n"
-                f"2. type = resolve_work_item_type(project_id, \"Initiative\") — finds or creates the type at workspace or project level automatically.\n"
-                f"3. create_work_item(project_id=project_id, type_id=type.id, name={repr(name)})."
-            )
+        _require_native_initiatives(
+            client,
+            workspace_slug,
+            f'Create {name!r} as an "Initiative" work item instead:\n'
+            "1. Work items belong to a project — if not named, ask the user which project to use.\n"
+            '2. type = resolve_work_item_type(project_id, "Initiative") — finds or creates the type automatically.\n'
+            f"3. create_work_item(project_id=project_id, type_id=type.id, name={name!r}).",
+        )
 
         data = CreateInitiative(
             name=name,
@@ -100,8 +123,18 @@ def register_initiative_tools(mcp: FastMCP) -> None:
 
         Returns:
             Initiative object
+
+        Raises:
+            ToolError: if the initiatives feature is disabled. When disabled, the
+                initiative is an "Initiative" work item — the error gives the steps.
         """
         client, workspace_slug = get_plane_client_context()
+        _require_native_initiatives(
+            client,
+            workspace_slug,
+            'This initiative is an "Initiative" work item. Retrieve it with '
+            "retrieve_work_item(project_id, work_item_id) instead.",
+        )
         return client.initiatives.retrieve(workspace_slug=workspace_slug, initiative_id=initiative_id)
 
     @mcp.tool()
@@ -130,8 +163,18 @@ def register_initiative_tools(mcp: FastMCP) -> None:
 
         Returns:
             Updated Initiative object
+
+        Raises:
+            ToolError: if the initiatives feature is disabled. When disabled, the
+                initiative is an "Initiative" work item — the error gives the steps.
         """
         client, workspace_slug = get_plane_client_context()
+        _require_native_initiatives(
+            client,
+            workspace_slug,
+            'This initiative is an "Initiative" work item. Update it with '
+            "update_work_item(project_id, work_item_id, ...) instead.",
+        )
 
         data = UpdateInitiative(
             name=name,
@@ -152,6 +195,16 @@ def register_initiative_tools(mcp: FastMCP) -> None:
 
         Args:
             initiative_id: UUID of the initiative
+
+        Raises:
+            ToolError: if the initiatives feature is disabled. When disabled, the
+                initiative is an "Initiative" work item — the error gives the steps.
         """
         client, workspace_slug = get_plane_client_context()
+        _require_native_initiatives(
+            client,
+            workspace_slug,
+            'This initiative is an "Initiative" work item. Delete it with '
+            "delete_work_item(project_id, work_item_id) instead.",
+        )
         client.initiatives.delete(workspace_slug=workspace_slug, initiative_id=initiative_id)

--- a/plane_mcp/tools/milestones.py
+++ b/plane_mcp/tools/milestones.py
@@ -157,6 +157,8 @@ def register_milestone_tools(mcp: FastMCP) -> None:
             add_ids: UUIDs of work items to add to the milestone
             remove_ids: UUIDs of work items to remove from the milestone
         """
+        if not add_ids and not remove_ids:
+            raise ValueError("At least one of add_ids or remove_ids must be provided.")
         client, workspace_slug = get_plane_client_context()
         if add_ids:
             client.milestones.add_work_items(

--- a/plane_mcp/tools/milestones.py
+++ b/plane_mcp/tools/milestones.py
@@ -140,48 +140,38 @@ def register_milestone_tools(mcp: FastMCP) -> None:
         client.milestones.delete(workspace_slug=workspace_slug, project_id=project_id, milestone_id=milestone_id)
 
     @mcp.tool()
-    def add_work_items_to_milestone(
+    def manage_milestone_work_items(
         project_id: str,
         milestone_id: str,
-        work_item_ids: list[str],
+        add_ids: list[str] | None = None,
+        remove_ids: list[str] | None = None,
     ) -> None:
         """
-        Add work items to a milestone.
+        Add or remove work items on a milestone in a single call.
+
+        At least one of add_ids or remove_ids must be provided.
 
         Args:
             project_id: UUID of the project
             milestone_id: UUID of the milestone
-            work_item_ids: List of work item UUIDs to add to the milestone
+            add_ids: UUIDs of work items to add to the milestone
+            remove_ids: UUIDs of work items to remove from the milestone
         """
         client, workspace_slug = get_plane_client_context()
-        client.milestones.add_work_items(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            milestone_id=milestone_id,
-            issue_ids=work_item_ids,
-        )
-
-    @mcp.tool()
-    def remove_work_items_from_milestone(
-        project_id: str,
-        milestone_id: str,
-        work_item_ids: list[str],
-    ) -> None:
-        """
-        Remove work items from a milestone.
-
-        Args:
-            project_id: UUID of the project
-            milestone_id: UUID of the milestone
-            work_item_ids: List of work item UUIDs to remove from the milestone
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.milestones.remove_work_items(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            milestone_id=milestone_id,
-            issue_ids=work_item_ids,
-        )
+        if add_ids:
+            client.milestones.add_work_items(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                milestone_id=milestone_id,
+                issue_ids=add_ids,
+            )
+        if remove_ids:
+            client.milestones.remove_work_items(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                milestone_id=milestone_id,
+                issue_ids=remove_ids,
+            )
 
     @mcp.tool()
     def list_milestone_work_items(

--- a/plane_mcp/tools/modules.py
+++ b/plane_mcp/tools/modules.py
@@ -29,20 +29,26 @@ def register_module_tools(mcp: FastMCP) -> None:
     @mcp.tool()
     def list_modules(
         project_id: str,
+        archived: bool = False,
         params: dict[str, Any] | None = None,
     ) -> list[Module]:
         """
-        List all modules in a project.
+        List modules in a project.
 
         Args:
-            workspace_slug: The workspace slug identifier
             project_id: UUID of the project
+            archived: Set True to list archived modules instead of active ones.
             params: Optional query parameters as a dictionary
 
         Returns:
             List of Module objects
         """
         client, workspace_slug = get_plane_client_context()
+        if archived:
+            archived_response: PaginatedArchivedModuleResponse = client.modules.list_archived(
+                workspace_slug=workspace_slug, project_id=project_id, params=params
+            )
+            return archived_response.results
         response: PaginatedModuleResponse = client.modules.list(
             workspace_slug=workspace_slug, project_id=project_id, params=params
         )
@@ -188,28 +194,6 @@ def register_module_tools(mcp: FastMCP) -> None:
         client.modules.delete(workspace_slug=workspace_slug, project_id=project_id, module_id=module_id)
 
     @mcp.tool()
-    def list_archived_modules(
-        project_id: str,
-        params: dict[str, Any] | None = None,
-    ) -> list[Module]:
-        """
-        List archived modules in a project.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-            params: Optional query parameters as a dictionary
-
-        Returns:
-            List of archived Module objects
-        """
-        client, workspace_slug = get_plane_client_context()
-        response: PaginatedArchivedModuleResponse = client.modules.list_archived(
-            workspace_slug=workspace_slug, project_id=project_id, params=params
-        )
-        return response.results
-
-    @mcp.tool()
     def manage_module_work_items(
         project_id: str,
         module_id: str,
@@ -301,7 +285,9 @@ def register_module_tools(mcp: FastMCP) -> None:
                 }
             raise
         return {
-            "results": [item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])],
+            "results": [
+                item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])
+            ],
             "total_count": response.total_count,
             "count": response.count,
             "next_cursor": response.next_cursor,

--- a/plane_mcp/tools/modules.py
+++ b/plane_mcp/tools/modules.py
@@ -210,49 +210,39 @@ def register_module_tools(mcp: FastMCP) -> None:
         return response.results
 
     @mcp.tool()
-    def add_work_items_to_module(
+    def manage_module_work_items(
         project_id: str,
         module_id: str,
-        work_item_ids: list[str],
+        add_ids: list[str] | None = None,
+        remove_ids: list[str] | None = None,
     ) -> None:
         """
-        Add work items to a module.
+        Add or remove work items on a module in a single call.
+
+        At least one of add_ids or remove_ids must be provided.
 
         Args:
             project_id: UUID of the project
             module_id: UUID of the module
-            work_item_ids: List of work item UUIDs to add to the module
+            add_ids: UUIDs of work items to add to the module
+            remove_ids: UUIDs of work items to remove from the module
         """
         client, workspace_slug = get_plane_client_context()
-        client.modules.add_work_items(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            module_id=module_id,
-            issue_ids=work_item_ids,
-        )
-
-    @mcp.tool()
-    def remove_work_item_from_module(
-        project_id: str,
-        module_id: str,
-        work_item_id: str,
-    ) -> None:
-        """
-        Remove a work item from a module.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-            module_id: UUID of the module
-            work_item_id: UUID of the work item to remove
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.modules.remove_work_item(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            module_id=module_id,
-            work_item_id=work_item_id,
-        )
+        if add_ids:
+            client.modules.add_work_items(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                module_id=module_id,
+                issue_ids=add_ids,
+            )
+        if remove_ids:
+            for work_item_id in remove_ids:
+                client.modules.remove_work_item(
+                    workspace_slug=workspace_slug,
+                    project_id=project_id,
+                    module_id=module_id,
+                    work_item_id=work_item_id,
+                )
 
     @mcp.tool()
     def list_module_work_items(
@@ -319,27 +309,17 @@ def register_module_tools(mcp: FastMCP) -> None:
         }
 
     @mcp.tool()
-    def archive_module(project_id: str, module_id: str) -> None:
+    def manage_module_archive(project_id: str, module_id: str, archive: bool) -> None:
         """
-        Archive a module.
+        Archive or unarchive a module.
 
         Args:
-            workspace_slug: The workspace slug identifier
             project_id: UUID of the project
             module_id: UUID of the module
+            archive: True to archive the module, False to unarchive it
         """
         client, workspace_slug = get_plane_client_context()
-        client.modules.archive(workspace_slug=workspace_slug, project_id=project_id, module_id=module_id)
-
-    @mcp.tool()
-    def unarchive_module(project_id: str, module_id: str) -> None:
-        """
-        Unarchive a module.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-            module_id: UUID of the module
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.modules.unarchive(workspace_slug=workspace_slug, project_id=project_id, module_id=module_id)
+        if archive:
+            client.modules.archive(workspace_slug=workspace_slug, project_id=project_id, module_id=module_id)
+        else:
+            client.modules.unarchive(workspace_slug=workspace_slug, project_id=project_id, module_id=module_id)

--- a/plane_mcp/tools/modules.py
+++ b/plane_mcp/tools/modules.py
@@ -227,6 +227,8 @@ def register_module_tools(mcp: FastMCP) -> None:
             add_ids: UUIDs of work items to add to the module
             remove_ids: UUIDs of work items to remove from the module
         """
+        if not add_ids and not remove_ids:
+            raise ValueError("At least one of add_ids or remove_ids must be provided.")
         client, workspace_slug = get_plane_client_context()
         if add_ids:
             client.modules.add_work_items(

--- a/plane_mcp/tools/pages.py
+++ b/plane_mcp/tools/pages.py
@@ -166,9 +166,10 @@ def register_page_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool()
-    def create_workspace_page(
+    def create_page(
         name: str,
         description_html: str,
+        project_id: str | None = None,
         access: int | None = None,
         color: str | None = None,
         is_locked: bool | None = None,
@@ -179,11 +180,15 @@ def register_page_tools(mcp: FastMCP) -> None:
         external_source: str | None = None,
     ) -> Page:
         """
-        Create a workspace page.
+        Create a page.
+
+        Creates a project page if project_id is given, otherwise a
+        workspace-level page.
 
         Args:
             name: Page name
             description_html: Page content in HTML format
+            project_id: UUID of the project. Omit to create a workspace page.
             access: Access level for the page (integer)
             color: Page color
             is_locked: Whether the page is locked
@@ -211,61 +216,13 @@ def register_page_tools(mcp: FastMCP) -> None:
             external_source=external_source,
         )
 
+        if project_id is not None:
+            return client.pages.create_project_page(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                data=data,
+            )
         return client.pages.create_workspace_page(
             workspace_slug=workspace_slug,
-            data=data,
-        )
-
-    @mcp.tool()
-    def create_project_page(
-        project_id: str,
-        name: str,
-        description_html: str,
-        access: int | None = None,
-        color: str | None = None,
-        is_locked: bool | None = None,
-        archived_at: str | None = None,
-        view_props: dict[str, Any] | None = None,
-        logo_props: dict[str, Any] | None = None,
-        external_id: str | None = None,
-        external_source: str | None = None,
-    ) -> Page:
-        """
-        Create a project page.
-
-        Args:
-            project_id: UUID of the project
-            name: Page name
-            description_html: Page content in HTML format
-            access: Access level for the page (integer)
-            color: Page color
-            is_locked: Whether the page is locked
-            archived_at: Archive timestamp (ISO 8601 format)
-            view_props: View properties dictionary
-            logo_props: Logo properties dictionary
-            external_id: External system identifier
-            external_source: External system source name
-
-        Returns:
-            Created Page object
-        """
-        client, workspace_slug = get_plane_client_context()
-
-        data = CreatePage(
-            name=name,
-            description_html=description_html,
-            access=access,
-            color=color,
-            is_locked=is_locked,
-            archived_at=archived_at,
-            view_props=view_props,
-            logo_props=logo_props,
-            external_id=external_id,
-            external_source=external_source,
-        )
-
-        return client.pages.create_project_page(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
             data=data,
         )

--- a/plane_mcp/tools/pages.py
+++ b/plane_mcp/tools/pages.py
@@ -13,39 +13,29 @@ def register_page_tools(mcp: FastMCP) -> None:
     """Register all page-related tools with the MCP server."""
 
     @mcp.tool()
-    def list_workspace_pages(
+    def list_pages(
+        project_id: str | None = None,
         params: dict[str, Any] | None = None,
     ) -> list[Page]:
         """
-        List all pages in a workspace.
+        List pages.
+
+        Lists a project's pages if project_id is given, otherwise workspace-level pages.
 
         Args:
+            project_id: UUID of the project. Omit to list workspace pages.
             params: Optional query parameters as a dictionary (e.g., per_page, cursor)
 
         Returns:
             List of Page objects
         """
         client, workspace_slug = get_plane_client_context()
-        response = client.pages.list_workspace_pages(workspace_slug=workspace_slug, params=params)
-        return response.results
-
-    @mcp.tool()
-    def list_project_pages(
-        project_id: str,
-        params: dict[str, Any] | None = None,
-    ) -> list[Page]:
-        """
-        List all pages in a project.
-
-        Args:
-            project_id: UUID of the project
-            params: Optional query parameters as a dictionary (e.g., per_page, cursor)
-
-        Returns:
-            List of Page objects
-        """
-        client, workspace_slug = get_plane_client_context()
-        response = client.pages.list_project_pages(workspace_slug=workspace_slug, project_id=project_id, params=params)
+        if project_id is not None:
+            response = client.pages.list_project_pages(
+                workspace_slug=workspace_slug, project_id=project_id, params=params
+            )
+        else:
+            response = client.pages.list_workspace_pages(workspace_slug=workspace_slug, params=params)
         return response.results
 
     @mcp.tool()
@@ -119,49 +109,32 @@ def register_page_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool()
-    def retrieve_workspace_page(
+    def retrieve_page(
         page_id: str,
+        project_id: str | None = None,
     ) -> Page:
         """
-        Retrieve a workspace page by ID.
+        Retrieve a page by ID.
+
+        Retrieves a project page if project_id is given, otherwise a workspace page.
 
         Args:
             page_id: UUID of the page
-            expand: Optional comma-separated list of fields to expand
-            fields: Optional comma-separated list of fields to include
+            project_id: UUID of the project. Omit for a workspace page.
 
         Returns:
             Page object
         """
         client, workspace_slug = get_plane_client_context()
 
+        if project_id is not None:
+            return client.pages.retrieve_project_page(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                page_id=page_id,
+            )
         return client.pages.retrieve_workspace_page(
             workspace_slug=workspace_slug,
-            page_id=page_id,
-        )
-
-    @mcp.tool()
-    def retrieve_project_page(
-        project_id: str,
-        page_id: str,
-    ) -> Page:
-        """
-        Retrieve a project page by ID.
-
-        Args:
-            project_id: UUID of the project
-            page_id: UUID of the page
-            expand: Optional comma-separated list of fields to expand
-            fields: Optional comma-separated list of fields to include
-
-        Returns:
-            Page object
-        """
-        client, workspace_slug = get_plane_client_context()
-
-        return client.pages.retrieve_project_page(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
             page_id=page_id,
         )
 

--- a/plane_mcp/tools/projects.py
+++ b/plane_mcp/tools/projects.py
@@ -275,29 +275,22 @@ def register_project_tools(mcp: FastMCP) -> None:
         client.projects.delete(workspace_slug=workspace_slug, project_id=project_id)
 
     @mcp.tool()
-    def archive_project(project_id: str) -> None:
+    def manage_project_archive(project_id: str, archive: bool) -> None:
         """
-        Archive a project.
+        Archive or unarchive a project.
 
         Archived projects are hidden from active project lists but not deleted.
         All work items, cycles, and modules are preserved.
 
         Args:
-            project_id: UUID of the project to archive
+            project_id: UUID of the project
+            archive: True to archive the project, False to unarchive it
         """
         client, workspace_slug = get_plane_client_context()
-        client.projects.archive(workspace_slug=workspace_slug, project_id=project_id)
-
-    @mcp.tool()
-    def unarchive_project(project_id: str) -> None:
-        """
-        Unarchive a project, restoring it to active status.
-
-        Args:
-            project_id: UUID of the project to unarchive
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.projects.unarchive(workspace_slug=workspace_slug, project_id=project_id)
+        if archive:
+            client.projects.archive(workspace_slug=workspace_slug, project_id=project_id)
+        else:
+            client.projects.unarchive(workspace_slug=workspace_slug, project_id=project_id)
 
     @mcp.tool()
     def get_project_worklog_summary(project_id: str) -> list[ProjectWorklogSummary]:

--- a/plane_mcp/tools/projects.py
+++ b/plane_mcp/tools/projects.py
@@ -324,21 +324,6 @@ def register_project_tools(mcp: FastMCP) -> None:
         return client.projects.get_members(workspace_slug=workspace_slug, project_id=project_id, params=params)
 
     @mcp.tool()
-    def get_project_features(project_id: str) -> ProjectFeature:
-        """
-        Get features of a project.
-
-        Args:
-            workspace_slug: The workspace slug identifier
-            project_id: UUID of the project
-
-        Returns:
-            ProjectFeature object containing enabled/disabled features
-        """
-        client, workspace_slug = get_plane_client_context()
-        return client.projects.get_features(workspace_slug=workspace_slug, project_id=project_id)
-
-    @mcp.tool()
     def update_project_features(
         project_id: str,
         modules: bool | None = None,

--- a/plane_mcp/tools/work_item_properties.py
+++ b/plane_mcp/tools/work_item_properties.py
@@ -384,54 +384,45 @@ def register_work_item_property_tools(mcp: FastMCP) -> None:
             )
 
     @mcp.tool()
-    def attach_properties_to_work_item_type(
+    def manage_work_item_type_properties(
         project_id: str,
         work_item_type_id: str,
-        property_ids: list[str],
-    ) -> list[str]:
+        attach_ids: list[str] | None = None,
+        detach_ids: list[str] | None = None,
+    ) -> list[str] | None:
         """
-        Attach one or more existing project-level properties to a work item type.
+        Attach or detach properties on a work item type in a single call.
 
-        Use after creating properties via create_work_item_property (project-level)
-        to associate them with a specific type.
+        At least one of attach_ids or detach_ids must be provided.
+        Detach does not delete the property — it only removes the association.
 
         Args:
             project_id: UUID of the project
             work_item_type_id: UUID of the work item type
-            property_ids: List of property UUIDs to attach
+            attach_ids: Property UUIDs to attach to the type
+            detach_ids: Property UUIDs to detach from the type
 
         Returns:
-            List of attached property UUIDs
+            List of attached property UUIDs if attach_ids was provided, else None
         """
         client, workspace_slug = get_plane_client_context()
-        return client.work_item_properties.attach_to_type(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            type_id=work_item_type_id,
-            property_ids=property_ids,
-        )
-
-    @mcp.tool()
-    def detach_property_from_work_item_type(
-        project_id: str,
-        work_item_type_id: str,
-        work_item_property_id: str,
-    ) -> None:
-        """
-        Detach a property from a work item type (does not delete the property).
-
-        Args:
-            project_id: UUID of the project
-            work_item_type_id: UUID of the work item type
-            work_item_property_id: UUID of the property to detach
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.work_item_properties.detach_from_type(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            type_id=work_item_type_id,
-            property_id=work_item_property_id,
-        )
+        result = None
+        if attach_ids:
+            result = client.work_item_properties.attach_to_type(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                type_id=work_item_type_id,
+                property_ids=attach_ids,
+            )
+        if detach_ids:
+            for property_id in detach_ids:
+                client.work_item_properties.detach_from_type(
+                    workspace_slug=workspace_slug,
+                    project_id=project_id,
+                    type_id=work_item_type_id,
+                    property_id=property_id,
+                )
+        return result
 
     @mcp.tool()
     def list_work_item_property_options(

--- a/plane_mcp/tools/work_item_types.py
+++ b/plane_mcp/tools/work_item_types.py
@@ -47,6 +47,9 @@ def register_work_item_type_tools(mcp: FastMCP) -> None:
         """
         Create a new work item type.
 
+        To get a usable type for a project (e.g. "Epic"), prefer resolve_work_item_type,
+        which finds-or-creates at the correct scope and never duplicates.
+
         Args:
             name: Work item type name
             project_id: UUID of the project. Omit for workspace-level type.
@@ -87,6 +90,9 @@ def register_work_item_type_tools(mcp: FastMCP) -> None:
         Imports one or more workspace-scoped work item types into a project so
         that they become available for use within that project.
 
+        For the common case of getting one named type usable in a project, prefer
+        resolve_work_item_type, which finds-or-creates and imports in one step.
+
         Args:
             project_id: UUID of the project
             work_item_type_ids: List of workspace-level work item type UUIDs to import
@@ -116,6 +122,10 @@ def register_work_item_type_tools(mcp: FastMCP) -> None:
           the project's work item types feature first if it is off.
 
         Matching is exact (case-sensitive, whitespace-stripped); an existing type is never duplicated.
+
+        Prefer this over manually combining get_workspace_features, list_work_item_types,
+        create_work_item_type, and import_work_item_types_to_project — it does all of
+        that deterministically.
 
         Args:
             project_id: UUID of the project the type must be usable in

--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -440,17 +440,24 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         client.work_items.delete(workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id)
 
     @mcp.tool()
-    def add_work_item_assignee(project_id: str, work_item_id: str, user_id: str) -> WorkItem:
+    def manage_work_item_assignee(
+        project_id: str,
+        work_item_id: str,
+        add_user_id: str | None = None,
+        remove_user_id: str | None = None,
+    ) -> WorkItem:
         """
-        Add an assignee to a work item without removing existing assignees.
+        Add or remove a single assignee on a work item without replacing the full list.
 
-        Use this instead of update_work_item when you only want to add one
-        assignee — update_work_item replaces the full assignees list.
+        Provide add_user_id, remove_user_id, or both. If both are given the
+        removal is applied first, then the addition. Already-assigned users in
+        add_user_id are silently skipped.
 
         Args:
             project_id: UUID of the project
             work_item_id: UUID of the work item
-            user_id: UUID of the user to add as assignee
+            add_user_id: UUID of the user to add as assignee
+            remove_user_id: UUID of the user to remove from assignees
 
         Returns:
             Updated WorkItem object
@@ -459,28 +466,37 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         current = client.work_items.retrieve(
             workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
         )
-        current_ids = [u.id for u in (current.assignees or []) if u.id]
-        if user_id not in current_ids:
-            current_ids.append(user_id)
+        ids = [u.id for u in (current.assignees or []) if u.id]
+        if remove_user_id:
+            ids = [uid for uid in ids if uid != remove_user_id]
+        if add_user_id and add_user_id not in ids:
+            ids.append(add_user_id)
         return client.work_items.update(
             workspace_slug=workspace_slug,
             project_id=project_id,
             work_item_id=work_item_id,
-            data=UpdateWorkItem(assignees=current_ids),
+            data=UpdateWorkItem(assignees=ids),
         )
 
     @mcp.tool()
-    def remove_work_item_assignee(project_id: str, work_item_id: str, user_id: str) -> WorkItem:
+    def manage_work_item_label(
+        project_id: str,
+        work_item_id: str,
+        add_label_id: str | None = None,
+        remove_label_id: str | None = None,
+    ) -> WorkItem:
         """
-        Remove an assignee from a work item without affecting other assignees.
+        Add or remove a single label on a work item without replacing the full list.
 
-        Use this instead of update_work_item when you only want to remove one
-        assignee — update_work_item replaces the full assignees list.
+        Provide add_label_id, remove_label_id, or both. If both are given the
+        removal is applied first, then the addition. Already-attached labels in
+        add_label_id are silently skipped.
 
         Args:
             project_id: UUID of the project
             work_item_id: UUID of the work item
-            user_id: UUID of the user to remove
+            add_label_id: UUID of the label to add
+            remove_label_id: UUID of the label to remove
 
         Returns:
             Updated WorkItem object
@@ -489,70 +505,16 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         current = client.work_items.retrieve(
             workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
         )
-        current_ids = [u.id for u in (current.assignees or []) if u.id and u.id != user_id]
+        ids = [lb.id for lb in (current.labels or []) if lb.id]
+        if remove_label_id:
+            ids = [lid for lid in ids if lid != remove_label_id]
+        if add_label_id and add_label_id not in ids:
+            ids.append(add_label_id)
         return client.work_items.update(
             workspace_slug=workspace_slug,
             project_id=project_id,
             work_item_id=work_item_id,
-            data=UpdateWorkItem(assignees=current_ids),
-        )
-
-    @mcp.tool()
-    def add_work_item_label(project_id: str, work_item_id: str, label_id: str) -> WorkItem:
-        """
-        Add a label to a work item without removing existing labels.
-
-        Use this instead of update_work_item when you only want to add one
-        label — update_work_item replaces the full labels list.
-
-        Args:
-            project_id: UUID of the project
-            work_item_id: UUID of the work item
-            label_id: UUID of the label to add
-
-        Returns:
-            Updated WorkItem object
-        """
-        client, workspace_slug = get_plane_client_context()
-        current = client.work_items.retrieve(
-            workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
-        )
-        current_ids = [lb.id for lb in (current.labels or []) if lb.id]
-        if label_id not in current_ids:
-            current_ids.append(label_id)
-        return client.work_items.update(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            work_item_id=work_item_id,
-            data=UpdateWorkItem(labels=current_ids),
-        )
-
-    @mcp.tool()
-    def remove_work_item_label(project_id: str, work_item_id: str, label_id: str) -> WorkItem:
-        """
-        Remove a label from a work item without affecting other labels.
-
-        Use this instead of update_work_item when you only want to remove one
-        label — update_work_item replaces the full labels list.
-
-        Args:
-            project_id: UUID of the project
-            work_item_id: UUID of the work item
-            label_id: UUID of the label to remove
-
-        Returns:
-            Updated WorkItem object
-        """
-        client, workspace_slug = get_plane_client_context()
-        current = client.work_items.retrieve(
-            workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
-        )
-        current_ids = [lb.id for lb in (current.labels or []) if lb.id and lb.id != label_id]
-        return client.work_items.update(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            work_item_id=work_item_id,
-            data=UpdateWorkItem(labels=current_ids),
+            data=UpdateWorkItem(labels=ids),
         )
 
     @mcp.tool()
@@ -617,41 +579,31 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         }
 
     @mcp.tool()
-    def archive_work_item(project_id: str, work_item_id: str) -> None:
+    def manage_work_item_archive(project_id: str, work_item_id: str, archive: bool) -> None:
         """
-        Archive a work item.
+        Archive or unarchive a work item.
 
         Only work items in a completed or cancelled state can be archived.
-        The work item will no longer appear in active work item lists.
+        Archived work items no longer appear in active work item lists.
 
         Args:
             project_id: UUID of the project
-            work_item_id: UUID of the work item to archive
+            work_item_id: UUID of the work item
+            archive: True to archive the work item, False to unarchive it
         """
         client, workspace_slug = get_plane_client_context()
-        client.work_items.archive(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            work_item_id=work_item_id,
-        )
-
-    @mcp.tool()
-    def unarchive_work_item(project_id: str, work_item_id: str) -> None:
-        """
-        Unarchive a work item.
-
-        Restores an archived work item back to active status.
-
-        Args:
-            project_id: UUID of the project
-            work_item_id: UUID of the work item to unarchive
-        """
-        client, workspace_slug = get_plane_client_context()
-        client.work_items.unarchive(
-            workspace_slug=workspace_slug,
-            project_id=project_id,
-            work_item_id=work_item_id,
-        )
+        if archive:
+            client.work_items.archive(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                work_item_id=work_item_id,
+            )
+        else:
+            client.work_items.unarchive(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                work_item_id=work_item_id,
+            )
 
     @mcp.tool()
     def search_work_items(

--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -1,5 +1,6 @@
 """Work item-related tools for Plane MCP Server."""
 
+from html import escape
 from typing import Annotated, Any, get_args
 
 from fastmcp import FastMCP
@@ -22,6 +23,21 @@ from plane_mcp.client import get_plane_client_context
 from plane_mcp.tools.pql_reference import PQL_FIELD_HINT, PQL_FULL_REFERENCE
 
 logger = get_logger(__name__)
+
+
+def _resolve_description_html(description_html: str | None, description_stripped: str | None) -> str | None:
+    """Resolve the description_html to persist.
+
+    Plane recomputes description_stripped server-side from description_html on
+    every save, so a stripped value sent on write is silently discarded. When the
+    caller supplies only plain text, wrap it into minimal HTML so the description
+    actually lands. description_html always wins when both are given.
+    """
+    if description_html is not None:
+        return description_html
+    if description_stripped is not None:
+        return "<p>" + escape(description_stripped).replace("\n", "<br/>") + "</p>"
+    return None
 
 
 def register_work_item_tools(mcp: FastMCP) -> None:
@@ -56,9 +72,13 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             cursor: From previous response's next_cursor.
             expand: Comma-separated relations to expand (e.g. assignees,labels,state).
             fields: Sparse fieldset — id, name, sequence_id, priority, state,
-                project, assignees, labels, type_id, start_date, target_date,
-                created_at, updated_at, created_by, is_draft. Use `project` not
-                `project_id`.
+                project, assignees, labels, type_id, description_html, start_date,
+                target_date, created_at, updated_at, created_by, is_draft. Use
+                `project` (not `project_id`) and `description_html` (there is no
+                `description` field). Any field you omit or misname comes back
+                null — a null here does NOT mean the item lacks that value; it
+                means it was not requested. To read the description, include
+                description_html; for the type, include type_id.
             external_id / external_source: Filter by external system.
 
         Returns:
@@ -104,7 +124,9 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             raise
 
         return {
-            "results": [item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])],
+            "results": [
+                item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])
+            ],
             "total_count": response.total_count,
             "count": response.count,
             "next_cursor": response.next_cursor,
@@ -195,7 +217,9 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             type_id: UUID of the work item type
             point: Story point value
             description_html: HTML description of the work item
-            description_stripped: Plain text description (stripped of HTML)
+            description_stripped: Plain text description. Convenience only — it is
+                wrapped into HTML and stored as description_html (Plane derives
+                description_stripped server-side). Ignored if description_html is set.
             priority: Priority level (urgent, high, medium, low, none)
             start_date: Start date (ISO 8601 format)
             target_date: Target/end date (ISO 8601 format)
@@ -223,8 +247,7 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             labels=labels,
             type_id=type_id,
             point=point,
-            description_html=description_html,
-            description_stripped=description_stripped,
+            description_html=_resolve_description_html(description_html, description_stripped),
             priority=validated_priority,
             start_date=start_date,
             target_date=target_date,
@@ -377,7 +400,9 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             type_id: UUID of the work item type
             point: Story point value
             description_html: HTML description of the work item
-            description_stripped: Plain text description (stripped of HTML)
+            description_stripped: Plain text description. Convenience only — it is
+                wrapped into HTML and stored as description_html (Plane derives
+                description_stripped server-side). Ignored if description_html is set.
             priority: Priority level (urgent, high, medium, low, none)
             start_date: Start date (ISO 8601 format)
             target_date: Target/end date (ISO 8601 format)
@@ -405,8 +430,7 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             labels=labels,
             type_id=type_id,
             point=point,
-            description_html=description_html,
-            description_stripped=description_stripped,
+            description_html=_resolve_description_html(description_html, description_stripped),
             priority=validated_priority,
             start_date=start_date,
             target_date=target_date,
@@ -569,7 +593,9 @@ def register_work_item_tools(mcp: FastMCP) -> None:
                 }
             raise
         return {
-            "results": [item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])],
+            "results": [
+                item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])
+            ],
             "total_count": response.total_count,
             "count": response.count,
             "next_cursor": response.next_cursor,

--- a/plane_mcp/tools/workspaces.py
+++ b/plane_mcp/tools/workspaces.py
@@ -1,6 +1,7 @@
 """Workspace-related tools for Plane MCP Server."""
 
 from fastmcp import FastMCP
+from plane.models.projects import ProjectFeature
 from plane.models.users import UserLite
 from plane.models.workspaces import WorkspaceFeature
 
@@ -22,14 +23,22 @@ def register_workspace_tools(mcp: FastMCP) -> None:
         return client.workspaces.get_members(workspace_slug=workspace_slug)
 
     @mcp.tool()
-    def get_workspace_features() -> WorkspaceFeature:
+    def get_features(project_id: str | None = None) -> WorkspaceFeature | ProjectFeature:
         """
-        Get features of the current workspace.
+        Get feature flags.
+
+        Returns a project's features if project_id is given, otherwise the
+        workspace's features.
+
+        Args:
+            project_id: UUID of the project. Omit for workspace features.
 
         Returns:
-            WorkspaceFeature object containing feature flags
+            ProjectFeature when project_id is given, otherwise WorkspaceFeature.
         """
         client, workspace_slug = get_plane_client_context()
+        if project_id is not None:
+            return client.projects.get_features(workspace_slug=workspace_slug, project_id=project_id)
         return client.workspaces.get_features(workspace_slug=workspace_slug)
 
     @mcp.tool()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -311,8 +311,7 @@ EXPECTED_TOOLS = [
     # Page tools
     "retrieve_workspace_page",
     "retrieve_project_page",
-    "create_workspace_page",
-    "create_project_page",
+    "create_page",
     # Work item activity tools
     "list_work_item_activities",
     "retrieve_work_item_activity",
@@ -356,12 +355,10 @@ EXPECTED_TOOLS = [
     "update_cycle",
     "delete_cycle",
     "list_archived_cycles",
-    "add_work_items_to_cycle",
-    "remove_work_item_from_cycle",
+    "manage_cycle_work_items",
     "list_cycle_work_items",
     "transfer_cycle_work_items",
-    "archive_cycle",
-    "unarchive_cycle",
+    "manage_cycle_archive",
     # Module tools
     "list_modules",
     "create_module",
@@ -369,11 +366,9 @@ EXPECTED_TOOLS = [
     "update_module",
     "delete_module",
     "list_archived_modules",
-    "add_work_items_to_module",
-    "remove_work_item_from_module",
+    "manage_module_work_items",
     "list_module_work_items",
-    "archive_module",
-    "unarchive_module",
+    "manage_module_archive",
     # Initiative tools
     "list_initiatives",
     "create_initiative",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -133,28 +133,10 @@ async def run_integration_test():
 
         # 5. Find or create an "Epic" work item type, and create an epic work item
         print("Finding or creating 'Epic' work item type...")
-        created_workspace_epic_type = False
-
-        project_types_result = await client.call_tool("list_work_item_types", {"project_id": project_id})
-        project_types = extract_result(project_types_result)
-        epic_type = next((t for t in project_types if t.get("name", "").lower() == "epic"), None)
-
-        if epic_type is None:
-            workspace_types_result = await client.call_tool("list_work_item_types", {})
-            workspace_types = extract_result(workspace_types_result)
-            if workspace_types:
-                new_type_result = await client.call_tool("create_work_item_type", {"name": "Epic"})
-                epic_type = extract_result(new_type_result)
-                created_workspace_epic_type = True
-                await client.call_tool(
-                    "import_work_item_types_to_project",
-                    {"project_id": project_id, "work_item_type_ids": [epic_type["id"]]},
-                )
-            else:
-                new_type_result = await client.call_tool(
-                    "create_work_item_type", {"name": "Epic", "project_id": project_id}
-                )
-                epic_type = extract_result(new_type_result)
+        epic_type_result = await client.call_tool(
+            "resolve_work_item_type", {"project_id": project_id, "name": "Epic"}
+        )
+        epic_type = extract_result(epic_type_result)
 
         epic_type_id = epic_type["id"]
         print(f"Using 'Epic' work item type: {epic_type_id}")
@@ -196,7 +178,7 @@ async def run_integration_test():
                 "pql": f'type = "{epic_type_id}"',
             },
         )
-        epics = extract_result(epics_result)["results"]
+        epics = extract_result(epics_result)
         print(f"Epics in project: {[e['id'] for e in epics]}")
 
         # 8. Create a milestone and associate it with the project and work items
@@ -263,11 +245,6 @@ async def run_integration_test():
             {"project_id": project_id, "work_item_id": epic_id},
         )
         print("Deleted epic")
-
-        if created_workspace_epic_type:
-            print("Deleting workspace-level 'Epic' work item type...")
-            await client.call_tool("delete_work_item_type", {"work_item_type_id": epic_type_id})
-            print("Deleted workspace-level 'Epic' work item type")
 
         # 10. Delete project
         print("Deleting project...")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -286,8 +286,8 @@ EXPECTED_TOOLS = [
     "update_state",
     "delete_state",
     # Page tools
-    "retrieve_workspace_page",
-    "retrieve_project_page",
+    "list_pages",
+    "retrieve_page",
     "create_page",
     # Work item activity tools
     "list_work_item_activities",
@@ -323,7 +323,7 @@ EXPECTED_TOOLS = [
     "delete_work_log",
     # Workspace tools
     "get_workspace_members",
-    "get_workspace_features",
+    "get_features",
     "update_workspace_features",
     # Cycle tools
     "list_cycles",
@@ -331,7 +331,6 @@ EXPECTED_TOOLS = [
     "retrieve_cycle",
     "update_cycle",
     "delete_cycle",
-    "list_archived_cycles",
     "manage_cycle_work_items",
     "list_cycle_work_items",
     "transfer_cycle_work_items",
@@ -342,7 +341,6 @@ EXPECTED_TOOLS = [
     "retrieve_module",
     "update_module",
     "delete_module",
-    "list_archived_modules",
     "manage_module_work_items",
     "list_module_work_items",
     "manage_module_archive",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -178,7 +178,7 @@ async def run_integration_test():
                 "pql": f'type = "{epic_type_id}"',
             },
         )
-        epics = extract_result(epics_result)
+        epics = extract_result(epics_result)["results"]
         print(f"Epics in project: {[e['id'] for e in epics]}")
 
         # 8. Create a milestone and associate it with the project and work items


### PR DESCRIPTION
## Description:
  Merging paired tools into single unified calls.

  ## Changes
  - `manage_work_item_assignee` — replaces add + remove assignee
  - `manage_work_item_label` — replaces add + remove label
  - `manage_work_item_archive` — replaces archive + unarchive work item
  - `manage_project_archive` — replaces archive + unarchive project
  - `manage_cycle_work_items` — replaces add + remove cycle work items
  - `manage_cycle_archive` — replaces archive + unarchive cycle (auto-sets end_date if needed)
  - `manage_module_work_items` — replaces add + remove module work items
  - `manage_module_archive` — replaces archive + unarchive module
  - `manage_milestone_work_items` — replaces add + remove milestone work items
  - `manage_work_item_type_properties` — replaces attach + detach type properties
  - `create_page` — replaces create_workspace_page + create_project_page
  - `retrieve_page` — replaces retrieve_workspace_page + retrieve_project_page (project page when `project_id` is given, workspace page otherwise)
  - `list_pages` — replaces list_workspace_pages + list_project_pages (scoped by optional `project_id`)
  - `get_features` — replaces get_workspace_features + get_project_features (scoped by optional `project_id`)
  - `list_cycles` — gains an `archived` flag, replacing the separate `list_archived_cycles`
  - `list_modules` — gains an `archived` flag, replacing the separate `list_archived_modules`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated cycle, module, milestone, and work-item operations into `manage_*` tools with optional add/remove parameters.
  * Unified archive control across projects, cycles, modules, and work items using an `archive` flag.
  * Unified pages APIs (`list_pages`, `retrieve_page`, `create_page`) and consolidated workspace/project feature retrieval into `get_features`.

* **Bug Fixes**
  * Improved work-item description handling by consistently converting plain text to HTML when needed.

* **Documentation**
  * Updated the README tool catalog to match renamed and consolidated tools.

* **Tests**
  * Updated integration test expectations for the new tool names and behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->