### PR TITLE
feat: enrich tool-call logs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -20,6 +20,10 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # Use when reverse-proxying alongside other apps.
 # MCP_PATH_PREFIX=
 
+# Optional: Logging — when true, include user info (PII such as the display
+# name) in logs alongside the opaque user id. Defaults to false.
+# LOG_USER_INFO=false
+
 # ---------------------------------------------------------------------------
 # Redis / Token storage (HTTP / SSE modes)
 # ---------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,4 @@ Integration tests in `tests/test_integration.py` use `FastMCP.Client` with `Stre
 | `PLANE_INTERNAL_BASE_URL` | http/sse (optional) | Internal URL for server-to-server calls |
 | `REDIS_HOST` / `REDIS_PORT` | http/sse (optional) | Token storage (falls back to in-memory) |
 | `PLANE_OAUTH_PROVIDER_*` | http/sse OAuth | OAuth client credentials and base URL |
+| `LOG_USER_INFO` | all (optional, default: false) | When `true`, include user info (PII such as display name) in logs alongside the opaque user id |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ export PLANE_WORKSPACE_SLUG="your-workspace-slug"
 
 **Note**: For remote HTTP transports (OAuth or PAT), authentication is handled via the connection method (OAuth flow or PAT headers) and does not require these environment variables.
 
+### Logging
+
+The server emits structured JSON logs. Each tool call is logged with its tool name, duration, status, and (when available) the opaque user id and workspace slug.
+
+- `LOG_USER_INFO`: When `true`, include user info (PII such as the display name) in logs alongside the opaque user id. Defaults to `false` so PII is never logged unless explicitly opted in. Only the OAuth and PAT (header) HTTP transports carry a display name; stdio is unaffected.
+
+```bash
+export LOG_USER_INFO="true"
+```
+
 ## Available Tools
 
 The server provides comprehensive tools for interacting with Plane. All tools use Pydantic models from the Plane SDK for type safety and validation.

--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -59,8 +59,18 @@ class JSONFormatter(logging.Formatter):
             "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
             "level": record.levelname,
             "logger": record.name,
-            "message": record.getMessage(),
         }
+        # The logging middleware emits a JSON object as its log message. Promote
+        # those keys to top-level fields (event, method, tool, duration_ms, ...)
+        raw_message = record.getMessage()
+        try:
+            parsed = json.loads(raw_message)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            log_entry.update(parsed)
+        else:
+            log_entry["message"] = raw_message
         user_id = getattr(record, "user_id", None)
         if user_id:
             log_entry["user_id"] = user_id
@@ -74,10 +84,8 @@ class JSONFormatter(logging.Formatter):
         if err:
             log_entry["user_context_enrichment_error"] = err
         if record.exc_info and record.exc_info[1]:
-            log_entry["error"] = {
-                "type": type(record.exc_info[1]).__name__,
-                "message": str(record.exc_info[1]),
-            }
+            log_entry["error"] = str(record.exc_info[1])
+            log_entry["error_type"] = type(record.exc_info[1]).__name__
         return json.dumps(log_entry)
 
 

--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -16,26 +16,38 @@ from starlette.routing import Mount
 
 from plane_mcp.server import get_header_mcp, get_oauth_mcp, get_stdio_mcp
 
+LOG_USER_INFO: bool = os.getenv("LOG_USER_INFO", "").lower() == "true"
+
 
 class UserContextFilter(logging.Filter):
-    """Attach the authenticated user's id to every log record.
+    """Attach authenticated user/workspace context to every log record.
 
     Pulls the current request's access token via FastMCP's dependency, which
-    returns None (never raises) outside a request context — so startup logs and
-    stdio mode simply carry no user info. Only the opaque user id is recorded;
-    PII such as the display name / email is intentionally never logged.
+    returns None (never raises) outside a request context — so startup logs fall
+    back to environment config and otherwise carry no user info.
+
+    Always logs the opaque user id (sub claim) and the workspace slug; neither is
+    PII. The display name IS PII and is only included when LOG_USER_INFO=true.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
         user_id = None
+        display_name = None
+        workspace_slug = None
         try:
             token = get_access_token()
             if token:
                 user_id = token.claims.get("sub")
+                workspace_slug = token.claims.get("workspace_slug")
+                if LOG_USER_INFO:
+                    display_name = token.claims.get("display_name")
         except Exception as exc:
             # Never let logging enrichment break a request, but leave a signal.
             record.user_context_enrichment_error = type(exc).__name__
         record.user_id = user_id
+        record.display_name = display_name
+        # stdio mode has no token; fall back to the configured workspace.
+        record.workspace_slug = workspace_slug or os.getenv("PLANE_WORKSPACE_SLUG") or None
         return True
 
 
@@ -52,6 +64,12 @@ class JSONFormatter(logging.Formatter):
         user_id = getattr(record, "user_id", None)
         if user_id:
             log_entry["user_id"] = user_id
+        workspace_slug = getattr(record, "workspace_slug", None)
+        if workspace_slug:
+            log_entry["workspace_slug"] = workspace_slug
+        display_name = getattr(record, "display_name", None)
+        if display_name:
+            log_entry["display_name"] = display_name
         err = getattr(record, "user_context_enrichment_error", None)
         if err:
             log_entry["user_context_enrichment_error"] = err

--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -40,6 +40,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = get_logger(__name__)
 
+# When true, user info (PII such as the display name) is included in logs.
+# Defaults to false so PII is never logged unless explicitly opted in.
+LOG_USER_INFO: bool = os.getenv("LOG_USER_INFO", "").lower() == "true"
+
 
 DEFAULT_PLANE_BASE_URL = "https://api.plane.so"
 
@@ -158,7 +162,11 @@ class PlaneOAuthTokenVerifier(TokenVerifier):
 
                 expires_at = int(time.time() + 3600)
 
-                logger.info(f"User: ({user.id}) - {user.display_name}")
+                # display_name is PII — only log it when explicitly opted in.
+                if LOG_USER_INFO:
+                    logger.info(f"User verified: ({user.id}) - {user.display_name}")
+                else:
+                    logger.info(f"User verified: ({user.id})")
 
                 installations_response = await client.get(
                     f"{base_url}/auth/o/app-installation/",

--- a/plane_mcp/middleware.py
+++ b/plane_mcp/middleware.py
@@ -1,0 +1,21 @@
+"""Custom FastMCP middleware for the Plane MCP Server."""
+
+from __future__ import annotations
+
+from fastmcp.server.middleware import MiddlewareContext
+from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+
+
+class PlaneLoggingMiddleware(StructuredLoggingMiddleware):
+    """StructuredLoggingMiddleware that also records the tool name."""
+
+    def _with_tool_name(self, context: MiddlewareContext, message: dict) -> dict:
+        if context.method == "tools/call":
+            message["tool"] = getattr(context.message, "name", "unknown")
+        return message
+
+    def _create_after_message(self, context: MiddlewareContext, start_time: float) -> dict:
+        return self._with_tool_name(context, super()._create_after_message(context, start_time))
+
+    def _create_error_message(self, context: MiddlewareContext, start_time: float, error: Exception) -> dict:
+        return self._with_tool_name(context, super()._create_error_message(context, start_time, error))

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 import os
 
 from fastmcp import FastMCP
-from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
 from mcp.types import Icon
 
 from plane_mcp.auth import PlaneHeaderAuthProvider, PlaneOAuthProvider
 from plane_mcp.instructions import SERVER_INSTRUCTIONS
+from plane_mcp.middleware import PlaneLoggingMiddleware
 from plane_mcp.storage import build_token_store
 from plane_mcp.tools import register_tools
 
@@ -47,7 +47,7 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
             ],
         ),
     )
-    oauth_mcp.add_middleware(StructuredLoggingMiddleware(include_payloads=True))
+    oauth_mcp.add_middleware(PlaneLoggingMiddleware(include_payloads=True))
     register_tools(oauth_mcp)
     return oauth_mcp
 
@@ -60,7 +60,7 @@ def get_header_mcp():
             required_scopes=["read", "write"],
         ),
     )
-    header_mcp.add_middleware(StructuredLoggingMiddleware(include_payloads=True))
+    header_mcp.add_middleware(PlaneLoggingMiddleware(include_payloads=True))
     register_tools(header_mcp)
     return header_mcp
 
@@ -70,6 +70,6 @@ def get_stdio_mcp():
         "Plane MCP Server (stdio)",
         instructions=SERVER_INSTRUCTIONS,
     )
-    stdio_mcp.add_middleware(StructuredLoggingMiddleware(include_payloads=True))
+    stdio_mcp.add_middleware(PlaneLoggingMiddleware(include_payloads=True))
     register_tools(stdio_mcp)
     return stdio_mcp


### PR DESCRIPTION
### Description

Improves structured logging for observability and tightens PII handling.

**Logging enrichment**

* Added `PlaneLoggingMiddleware` (subclasses FastMCP's `StructuredLoggingMiddleware`) to include the `tool` name in `tools/call` log entries.
* Added `workspace_slug` to every log record via `UserContextFilter` (from token claims, or `PLANE_WORKSPACE_SLUG` in stdio), enabling per-workspace grouping and analytics.

**PII handling**

* Added a new `LOG_USER_INFO` environment variable (default: `false`).
* When `true`, user information (PII such as `display_name`) is included in logs alongside the opaque `user_id`.
* When `false`, only the non-PII `user_id` and `workspace_slug` are logged.

**Transport note**

* `stdio` does not log `user_id` or `display_name`. It runs as a single user authenticated via `PLANE_API_KEY` (no OAuth/PAT token, so no `sub` or `display_name` claims are available).
* Only `workspace_slug` (from environment variables) is logged in `stdio`.
* `LOG_USER_INFO` is a no-op for `stdio`.

### Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] Feature (non-breaking change which adds functionality)
* [ ] Improvement (change that would cause existing functionality to not work as expected)
* [ ] Code refactoring
* [ ] Performance improvements
* [x] Documentation update

### Sample Logs

#### HTTP with user info (`LOG_USER_INFO=true` → `display_name` included)

```json
{"timestamp": "2026-06-17T10:34:44.498814+00:00", "level": "INFO", "logger": "fastmcp.plane_mcp.auth.plane_oauth_provider", "message": "User verified: (4161e0f8-48a2-49b4-a43a-458465337135) - akhil.vamshi"}

{"timestamp": "2026-06-17T10:34:44.532392+00:00", "level": "INFO", "logger": "fastmcp.middleware.structured_logging", "event": "request_start", "method": "tools/call", "source": "client", "payload": "{\"task\":null,\"_meta\":null,\"name\":\"list_projects\",\"arguments\":{}}", "payload_type": "CallToolRequestParams", "user_id": "4161e0f8-48a2-49b4-a43a-458465337135", "workspace_slug": "bronze", "display_name": "akhil.vamshi"}

{"timestamp": "2026-06-17T10:34:44.630735+00:00", "level": "INFO", "logger": "fastmcp.middleware.structured_logging", "event": "request_success", "method": "tools/call", "source": "client", "duration_ms": 98.26, "tool": "list_projects", "user_id": "4161e0f8-48a2-49b4-a43a-458465337135", "workspace_slug": "bronze", "display_name": "akhil.vamshi"}
```

#### HTTP without user info (default → no `display_name`, `user_id` only)

```json
{"timestamp": "2026-06-17T11:55:51.043796+00:00", "level": "INFO", "logger": "fastmcp.plane_mcp.auth.plane_oauth_provider", "message": "User verified: (4161e0f8-48a2-49b4-a43a-458465337135)"}

{"timestamp": "2026-06-17T11:55:51.084374+00:00", "level": "INFO", "logger": "fastmcp.middleware.structured_logging", "event": "request_start", "method": "tools/call", "source": "client", "payload": "{\"task\":null,\"_meta\":null,\"name\":\"list_projects\",\"arguments\":{}}", "payload_type": "CallToolRequestParams", "user_id": "4161e0f8-48a2-49b4-a43a-458465337135", "workspace_slug": "bronze"}

{"timestamp": "2026-06-17T11:55:51.175255+00:00", "level": "INFO", "logger": "fastmcp.middleware.structured_logging", "event": "request_success", "method": "tools/call", "source": "client", "duration_ms": 90.76, "tool": "list_projects", "user_id": "4161e0f8-48a2-49b4-a43a-458465337135", "workspace_slug": "bronze"}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `LOG_USER_INFO` environment variable (defaults to false) to optionally include user display names in server logs.

* **Documentation**
  * Enhanced README with new Logging section describing structured JSON logs and `LOG_USER_INFO` configuration.
  * Updated CLAUDE.md documenting the `LOG_USER_INFO` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->