### PR TITLE
fix: verify header API key against Plane API

### DIFF
--- a/plane_mcp/auth/plane_header_auth_provider.py
+++ b/plane_mcp/auth/plane_header_auth_provider.py
@@ -1,15 +1,23 @@
+import os
 import time
 
+import httpx
 from fastmcp.server.auth import TokenVerifier
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.utilities.logging import get_logger
 
 logger = get_logger(__name__)
 
+DEFAULT_PLANE_BASE_URL = "https://api.plane.so"
+
 
 class PlaneHeaderAuthProvider(TokenVerifier):
-    def __init__(self, required_scopes: list[str] | None = None):
+    def __init__(self, required_scopes: list[str] | None = None, timeout_seconds: int = 10):
         super().__init__(required_scopes=required_scopes)
+        self.timeout_seconds = timeout_seconds
+        self.plane_base_url = (
+            os.getenv("PLANE_INTERNAL_BASE_URL") or os.getenv("PLANE_BASE_URL", DEFAULT_PLANE_BASE_URL)
+        ).rstrip("/")
 
     async def verify_token(self, token: str) -> AccessToken | None:
         try:
@@ -20,7 +28,21 @@ class PlaneHeaderAuthProvider(TokenVerifier):
             if token:
                 workspace_slug = headers.get("x-workspace-slug")
                 if workspace_slug:
-                    logger.info("Using API key from HTTP headers")
+                    logger.info("Verifying API key against Plane API")
+                    user_url = f"{self.plane_base_url}/api/v1/users/me/"
+                    async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                        response = await client.get(
+                            user_url,
+                            headers={
+                                "x-api-key": token,
+                                "Content-Type": "application/json",
+                            },
+                        )
+                        if response.status_code != 200:
+                            logger.warning("API key verification failed: %s", response.status_code)
+                            return None
+
+                    logger.info("API key verified successfully")
                     expires_at = int(time.time() + 3600)
                     return AccessToken(
                         token=token,
@@ -34,6 +56,9 @@ class PlaneHeaderAuthProvider(TokenVerifier):
                     )
                 else:
                     logger.warning("x-api-key header found but x-workspace-slug is missing")
+        except httpx.RequestError as e:
+            logger.warning("API key verification request failed: %s", e)
+            return None
         except RuntimeError:
             # No active HTTP request available (e.g., stdio transport)
             logger.debug("No active HTTP request available for header check")


### PR DESCRIPTION
## Summary

`PlaneHeaderAuthProvider` previously accepted any `x-api-key` header without validating it — it only logged that a key was present and immediately issued an `AccessToken`. This means an invalid or revoked key would still pass MCP auth.

This change verifies the API key against the Plane API before granting access.

## Changes

- **Verify the key**: call `GET /api/v1/users/me/` with the supplied `x-api-key`. Reject the token (`return None`) on any non-`200` response.
- **Base URL resolution**: prefer `PLANE_INTERNAL_BASE_URL`, then `PLANE_BASE_URL`, defaulting to `https://api.plane.so` — consistent with server-to-server call handling elsewhere.
- **Configurable timeout**: `timeout_seconds` constructor arg (default `10s`).
- **Fail closed** on `httpx.RequestError` (network/timeout) — returns `None` rather than granting access.

## Notes

- stdio transport is unaffected (no active HTTP request → existing `RuntimeError` path).
- Adds an outbound request per token verification; the resulting `AccessToken` is still cached for 1h via `expires_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
