### PR TITLE
perf: use lite endpoints for project/cycle/module lists to fix large-workspace timeouts

### DIFF
--- a/plane_mcp/tools/cycles.py
+++ b/plane_mcp/tools/cycles.py
@@ -10,12 +10,12 @@ from plane.models.cycles import (
     CreateCycle,
     Cycle,
     PaginatedArchivedCycleResponse,
-    PaginatedCycleResponse,
+    PaginatedCycleLiteResponse,
     PaginatedCycleWorkItemResponse,
     TransferCycleWorkItemsRequest,
     UpdateCycle,
 )
-from plane.models.query_params import WorkItemQueryParams
+from plane.models.query_params import LiteListQueryParams, WorkItemQueryParams
 from pydantic import Field
 
 from plane_mcp.client import get_plane_client_context
@@ -31,29 +31,36 @@ def register_cycle_tools(mcp: FastMCP) -> None:
     def list_cycles(
         project_id: str,
         archived: bool = False,
-        params: dict[str, Any] | None = None,
-    ) -> list[Cycle]:
+        cursor: str | None = None,
+        per_page: int | None = None,
+        order_by: str | None = None,
+    ) -> PaginatedCycleLiteResponse | PaginatedArchivedCycleResponse:
         """
         List cycles in a project.
 
         Args:
             project_id: UUID of the project
             archived: Set True to list archived cycles instead of active ones.
-            params: Optional query parameters as a dictionary
+            cursor: Pagination cursor from a previous response's next_cursor
+                (form "{per_page}:{page}:{offset}"). Omit for the first page.
+            per_page: Number of results per page (1-1000, default and max 1000).
+            order_by: Field to order results by. Prefix with '-' for descending.
 
         Returns:
-            List of Cycle objects
+            Paginated envelope: results (lite cycles) + total_count,
+            next_cursor, next_page_results.
         """
         client, workspace_slug = get_plane_client_context()
+        params = LiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by)
         if archived:
-            archived_response: PaginatedArchivedCycleResponse = client.cycles.list_archived(
-                workspace_slug=workspace_slug, project_id=project_id, params=params
+            return client.cycles.list_archived(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                params=params.model_dump(exclude_none=True),
             )
-            return archived_response.results
-        response: PaginatedCycleResponse = client.cycles.list(
+        return client.cycles.list_lite(
             workspace_slug=workspace_slug, project_id=project_id, params=params
         )
-        return response.results
 
     @mcp.tool()
     def create_cycle(

--- a/plane_mcp/tools/cycles.py
+++ b/plane_mcp/tools/cycles.py
@@ -15,7 +15,8 @@ from plane.models.cycles import (
     TransferCycleWorkItemsRequest,
     UpdateCycle,
 )
-from plane.models.query_params import LiteListQueryParams, WorkItemQueryParams
+from plane.models.enums import CycleViewEnum
+from plane.models.query_params import CycleLiteListQueryParams, LiteListQueryParams, WorkItemQueryParams
 from pydantic import Field
 
 from plane_mcp.client import get_plane_client_context
@@ -31,16 +32,20 @@ def register_cycle_tools(mcp: FastMCP) -> None:
     def list_cycles(
         project_id: str,
         archived: bool = False,
+        cycle_view: CycleViewEnum | None = None,
         cursor: str | None = None,
         per_page: int | None = None,
         order_by: str | None = None,
     ) -> PaginatedCycleLiteResponse | PaginatedArchivedCycleResponse:
         """
-        List cycles in a project.
+        List cycles in a project. Active (non-archived) cycles by default.
 
         Args:
             project_id: UUID of the project
             archived: Set True to list archived cycles instead of active ones.
+            cycle_view: Filter active cycles by status — "current" (running now),
+                "upcoming" (starts later), "completed" (ended), "draft" (no dates),
+                or "incomplete" (not yet finished). Ignored when archived is True.
             cursor: Pagination cursor from a previous response's next_cursor
                 (form "{per_page}:{page}:{offset}"). Omit for the first page.
             per_page: Number of results per page (1-1000, default and max 1000).
@@ -51,16 +56,15 @@ def register_cycle_tools(mcp: FastMCP) -> None:
             next_cursor, next_page_results.
         """
         client, workspace_slug = get_plane_client_context()
-        params = LiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by)
         if archived:
+            params = LiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by)
             return client.cycles.list_archived(
                 workspace_slug=workspace_slug,
                 project_id=project_id,
                 params=params.model_dump(exclude_none=True),
             )
-        return client.cycles.list_lite(
-            workspace_slug=workspace_slug, project_id=project_id, params=params
-        )
+        params = CycleLiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by, cycle_view=cycle_view)
+        return client.cycles.list_lite(workspace_slug=workspace_slug, project_id=project_id, params=params)
 
     @mcp.tool()
     def create_cycle(

--- a/plane_mcp/tools/cycles.py
+++ b/plane_mcp/tools/cycles.py
@@ -15,7 +15,7 @@ from plane.models.cycles import (
     TransferCycleWorkItemsRequest,
     UpdateCycle,
 )
-from plane.models.enums import CycleViewEnum
+from plane.models.enums import CycleStatusEnum
 from plane.models.query_params import CycleLiteListQueryParams, LiteListQueryParams, WorkItemQueryParams
 from pydantic import Field
 
@@ -32,7 +32,7 @@ def register_cycle_tools(mcp: FastMCP) -> None:
     def list_cycles(
         project_id: str,
         archived: bool = False,
-        cycle_view: CycleViewEnum | None = None,
+        status: CycleStatusEnum | None = None,
         cursor: str | None = None,
         per_page: int | None = None,
         order_by: str | None = None,
@@ -43,7 +43,7 @@ def register_cycle_tools(mcp: FastMCP) -> None:
         Args:
             project_id: UUID of the project
             archived: Set True to list archived cycles instead of active ones.
-            cycle_view: Filter active cycles by status — "current" (running now),
+            status: Filter active cycles by status — "current" (running now),
                 "upcoming" (starts later), "completed" (ended), "draft" (no dates),
                 or "incomplete" (not yet finished). Ignored when archived is True.
             cursor: Pagination cursor from a previous response's next_cursor
@@ -63,7 +63,7 @@ def register_cycle_tools(mcp: FastMCP) -> None:
                 project_id=project_id,
                 params=params.model_dump(exclude_none=True),
             )
-        params = CycleLiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by, cycle_view=cycle_view)
+        params = CycleLiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by, status=status)
         return client.cycles.list_lite(workspace_slug=workspace_slug, project_id=project_id, params=params)
 
     @mcp.tool()

--- a/plane_mcp/tools/modules.py
+++ b/plane_mcp/tools/modules.py
@@ -10,11 +10,11 @@ from plane.models.modules import (
     CreateModule,
     Module,
     PaginatedArchivedModuleResponse,
-    PaginatedModuleResponse,
+    PaginatedModuleLiteResponse,
     PaginatedModuleWorkItemResponse,
     UpdateModule,
 )
-from plane.models.query_params import WorkItemQueryParams
+from plane.models.query_params import LiteListQueryParams, WorkItemQueryParams
 from pydantic import Field
 
 from plane_mcp.client import get_plane_client_context
@@ -30,29 +30,36 @@ def register_module_tools(mcp: FastMCP) -> None:
     def list_modules(
         project_id: str,
         archived: bool = False,
-        params: dict[str, Any] | None = None,
-    ) -> list[Module]:
+        cursor: str | None = None,
+        per_page: int | None = None,
+        order_by: str | None = None,
+    ) -> PaginatedModuleLiteResponse | PaginatedArchivedModuleResponse:
         """
         List modules in a project.
 
         Args:
             project_id: UUID of the project
             archived: Set True to list archived modules instead of active ones.
-            params: Optional query parameters as a dictionary
+            cursor: Pagination cursor from a previous response's next_cursor
+                (form "{per_page}:{page}:{offset}"). Omit for the first page.
+            per_page: Number of results per page (1-1000, default and max 1000).
+            order_by: Field to order results by. Prefix with '-' for descending.
 
         Returns:
-            List of Module objects
+            Paginated envelope: results (lite modules) + total_count,
+            next_cursor, next_page_results.
         """
         client, workspace_slug = get_plane_client_context()
+        params = LiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by)
         if archived:
-            archived_response: PaginatedArchivedModuleResponse = client.modules.list_archived(
-                workspace_slug=workspace_slug, project_id=project_id, params=params
+            return client.modules.list_archived(
+                workspace_slug=workspace_slug,
+                project_id=project_id,
+                params=params.model_dump(exclude_none=True),
             )
-            return archived_response.results
-        response: PaginatedModuleResponse = client.modules.list(
+        return client.modules.list_lite(
             workspace_slug=workspace_slug, project_id=project_id, params=params
         )
-        return response.results
 
     @mcp.tool()
     def create_module(

--- a/plane_mcp/tools/projects.py
+++ b/plane_mcp/tools/projects.py
@@ -20,7 +20,7 @@ from plane.models.projects import (
     ProjectWorklogSummary,
     UpdateProject,
 )
-from plane.models.query_params import LiteListQueryParams
+from plane.models.query_params import ProjectLiteListQueryParams
 from plane.models.users import UserLite
 
 from plane_mcp.client import get_plane_client_context
@@ -34,17 +34,20 @@ def register_project_tools(mcp: FastMCP) -> None:
         cursor: str | None = None,
         per_page: int | None = None,
         order_by: str | None = None,
+        include_archived: bool = False,
     ) -> PaginatedProjectLiteResponse:
         """
         List projects in a workspace (lite, paginated).
 
         Trimmed fields: id, identifier, name, description, emoji, icon_prop,
-        cover_image, cover_image_url. For full detail use retrieve_project.
+        cover_image, cover_image_url, archived_at. For full detail use retrieve_project.
 
         Args:
             cursor: Prior response's next_cursor; omit for first page.
             per_page: Results per page (1-1000, default 1000).
             order_by: Sort field; prefix '-' for descending.
+            include_archived: Set True to also include archived projects.
+                Archived projects are excluded by default.
 
         Returns:
             Paginated envelope: results + total_count, next_cursor,
@@ -52,7 +55,9 @@ def register_project_tools(mcp: FastMCP) -> None:
         """
         client, workspace_slug = get_plane_client_context()
 
-        params = LiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by)
+        params = ProjectLiteListQueryParams(
+            cursor=cursor, per_page=per_page, order_by=order_by, include_archived=include_archived
+        )
 
         return client.projects.list_lite(workspace_slug=workspace_slug, params=params)
 

--- a/plane_mcp/tools/projects.py
+++ b/plane_mcp/tools/projects.py
@@ -14,13 +14,13 @@ from plane.models.estimates import (
 )
 from plane.models.projects import (
     CreateProject,
-    PaginatedProjectResponse,
+    PaginatedProjectLiteResponse,
     Project,
     ProjectFeature,
     ProjectWorklogSummary,
     UpdateProject,
 )
-from plane.models.query_params import PaginatedQueryParams
+from plane.models.query_params import LiteListQueryParams
 from plane.models.users import UserLite
 
 from plane_mcp.client import get_plane_client_context
@@ -33,40 +33,28 @@ def register_project_tools(mcp: FastMCP) -> None:
     def list_projects(
         cursor: str | None = None,
         per_page: int | None = None,
-        expand: str | None = None,
-        fields: str | None = None,
         order_by: str | None = None,
-    ) -> list[Project]:
+    ) -> PaginatedProjectLiteResponse:
         """
-        List all projects in a workspace.
+        List projects in a workspace (lite, paginated).
+
+        Trimmed fields: id, identifier, name, description, emoji, icon_prop,
+        cover_image, cover_image_url. For full detail use retrieve_project.
 
         Args:
-            workspace_slug: The workspace slug identifier
-            cursor: Pagination cursor for getting next set of results
-            per_page: Number of results per page (1-100)
-            expand: Comma-separated list of related fields to expand in response
-            fields: Comma-separated list of fields to include in response
-            order_by: Field to order results by. Prefix with '-' for descending order
+            cursor: Prior response's next_cursor; omit for first page.
+            per_page: Results per page (1-1000, default 1000).
+            order_by: Sort field; prefix '-' for descending.
 
         Returns:
-            List of Project objects
+            Paginated envelope: results + total_count, next_cursor,
+            next_page_results (page again while next_page_results is true).
         """
         client, workspace_slug = get_plane_client_context()
 
-        params = PaginatedQueryParams(
-            cursor=cursor,
-            per_page=per_page,
-            expand=expand,
-            fields=fields,
-            order_by=order_by,
-        )
+        params = LiteListQueryParams(cursor=cursor, per_page=per_page, order_by=order_by)
 
-        response: PaginatedProjectResponse = client.projects.list(
-            workspace_slug=workspace_slug,
-            params=params,
-        )
-
-        return response.results
+        return client.projects.list_lite(workspace_slug=workspace_slug, params=params)
 
     @mcp.tool()
     def create_project(

--- a/plane_mcp/tools/projects.py
+++ b/plane_mcp/tools/projects.py
@@ -35,7 +35,6 @@ def register_project_tools(mcp: FastMCP) -> None:
         cursor: str | None = None,
         per_page: int | None = None,
         order_by: str | None = None,
-        include_archived: bool = False,
     ) -> PaginatedProjectLiteResponse:
         """
         List projects in a workspace (lite, paginated).
@@ -47,8 +46,6 @@ def register_project_tools(mcp: FastMCP) -> None:
             cursor: Prior response's next_cursor; omit for first page.
             per_page: Results per page (1-1000, default 1000).
             order_by: Sort field; prefix '-' for descending.
-            include_archived: Set True to also include archived projects.
-                Archived projects are excluded by default.
 
         Returns:
             Paginated envelope: results + total_count, next_cursor,
@@ -57,7 +54,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         client, workspace_slug = get_plane_client_context()
 
         params = ProjectLiteListQueryParams(
-            cursor=cursor, per_page=per_page, order_by=order_by, include_archived=include_archived
+            cursor=cursor, per_page=per_page, order_by=order_by, include_archived=False
         )
 
         return client.projects.list_lite(workspace_slug=workspace_slug, params=params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["mcp", "plane", "fastmcp", "ai", "automation"]
 
 dependencies = [
     "fastmcp==3.2.0",
-    "plane-sdk==0.2.16",
+    "plane-sdk==0.2.19",
     "py-key-value-aio[redis]>=0.4.4,<0.5.0",
     "mcp==1.26.0",
     "PyJWT>=2.12.0",


### PR DESCRIPTION
### Description

`list_projects`, `list_cycles`, `list_modules` hit the heavy list endpoints (per-row metric annotations, up to 1000 rows/page) → timed out on large workspaces.

Now call the read-only **lite** endpoints (no metric annotations) and return a cursor-paginated envelope:

- `list_projects` → `projects-lite` (trimmed fields; dropped `expand`/`fields`; use `retrieve_project` for full detail)
- `list_cycles` → `cycles-lite` for active; `archived=True` unchanged
- `list_modules` → `modules-lite`, same pattern

 Bumps `plane-sdk` to `0.2.19`.

### Type of Change

- [x] Feature (non-breaking change which adds functionality)
- [x] Improvement (change that would cause existing functionality to not work as expected)
- [x] Performance improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated project, module, and cycle listing tools to use lightweight, paginated results for faster browsing.
  * Added cursor-based paging, per-page limits, and sorting controls to listings.
  * Cycle listings now support status filtering; archived listings use the same paginated experience.
  * Module and project listings no longer accept the previous generic parameter dict or extra expand/fields inputs.

* **Chores**
  * Updated the underlying SDK to the latest patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->