### PR TITLE
fix: correct OAuth redirect allowlist

### DIFF
--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -37,11 +37,11 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
                 "http://127.0.0.1:*",
                 "http://127.0.0.1:*/*",
                 # Known MCP client custom protocol schemes
-                "cursor://*",
-                "vscode://*",
-                "vscode-insiders://*",
-                "windsurf://*",
-                "claude://*",
+                "cursor://anysphere.cursor-mcp/oauth/*",
+                "https://www.cursor.com/*",
+                "https://vscode.dev/redirect",
+                "https://insiders.vscode.dev/redirect",
+                "https://antigravity.google/oauth-callback",
                 # Claude.ai web client
                 "https://claude.ai/*",
             ],

--- a/tests/test_oauth_security.py
+++ b/tests/test_oauth_security.py
@@ -29,11 +29,12 @@ ALLOWED_REDIRECT_URI_PATTERNS = [
     "http://localhost:*/*",
     "http://127.0.0.1:*",
     "http://127.0.0.1:*/*",
-    "cursor://*",
-    "vscode://*",
-    "vscode-insiders://*",
-    "windsurf://*",
-    "claude://*",
+    "cursor://anysphere.cursor-mcp/oauth/*",
+    "https://www.cursor.com/*",
+    "https://vscode.dev/redirect",
+    "https://insiders.vscode.dev/redirect",
+    "https://antigravity.google/oauth-callback",
+    "https://claude.ai/*",
 ]
 
 


### PR DESCRIPTION
### Description

Fixes OAuth redirect URI matching for desktop clients using custom URI schemes.

FastMCP's redirect URI matcher requires an exact host (or `*.domain`). The previous redirect URI patterns did not satisfy this requirement, causing OAuth authentication to fail with:

> "redirect URI ... does not match allowed patterns"

Updated the redirect URI allowlist to use the correct hosts:

* `cursor://anysphere.cursor-mcp/oauth/*` — Cursor Desktop
* `https://www.cursor.com/*` — Cursor Cloud
* `https://vscode.dev/redirect`
* `https://insiders.vscode.dev/redirect` — VS Code
* `https://antigravity.google/oauth-callback` — Antigravity

No changes were required for Windsurf, Zed, Kiro, JetBrains, or Claude Desktop, as they are already supported via loopback redirects or PAT authentication.

### Type of Change

* [x] Bug fix
* [ ] Feature
* [ ] Improvement
* [ ] Code refactoring
* [ ] Performance improvements
* [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in redirect validation to ensure only supported redirect destinations are accepted across common app browsers.
  * Tightened the allowlist of allowed redirect URI patterns to reduce invalid or unexpected login callback URLs and improve overall sign-in reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->