### PR TITLE
chore: add ChatGPT OAuth connector redirect URIs to OAuth allowlist

### DIFF
--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -44,6 +44,9 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
                 "https://antigravity.google/oauth-callback",
                 # Claude.ai web client
                 "https://claude.ai/*",
+                # ChatGPT connectors — per-connector callback + legacy redirect
+                "https://chatgpt.com/connector/oauth/*",
+                "https://chatgpt.com/connector_platform_oauth_redirect",
             ],
         ),
     )


### PR DESCRIPTION
### Description

Adds the ChatGPT OAuth connector redirect URIs to the MCP server's OAuth redirect allowlist.

This change includes support for:

* `https://chatgpt.com/connector/oauth/*` (per-connector callback)
* `https://chatgpt.com/connector_platform_oauth_redirect` (legacy redirect)

This ensures OAuth flows initiated through ChatGPT Connectors are accepted by the server.

### Type of Change

* [x] Improvement
* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] Feature (non-breaking change which adds functionality)
* [ ] Code refactoring
* [ ] Performance improvements
* [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded OAuth redirect support to include ChatGPT connector callback patterns, improving compatibility for connector sign-in flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->