### PR TITLE
feat: load extra OAuth redirect URIs from env

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -15,6 +15,11 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # PLANE_OAUTH_PROVIDER_CLIENT_SECRET=your_oauth_client_secret
 # PLANE_OAUTH_PROVIDER_BASE_URL=http://localhost:8211
 # PLANE_OAUTH_PROVIDER_ENABLE_CIMD=false  # Set to true to enable client-id-metadata-document support
+# Extra redirect URI patterns appended to the built-in OAuth allowlist
+# (comma-separated). Onboard a new MCP client without a code change/release.
+# Glob: `*` matches any port/path segment or subdomain. Keep the host pinned;
+# wildcard only the port/path.
+# PLANE_OAUTH_ALLOWED_REDIRECT_URIS=https://newclient.com/cb,https://other.app/oauth/*
 
 # Optional: Route prefix — prepended to all mounted routes.
 # Use when reverse-proxying alongside other apps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,4 +86,5 @@ Integration tests in `tests/test_integration.py` use `FastMCP.Client` with `Stre
 | `PLANE_INTERNAL_BASE_URL` | http/sse (optional) | Internal URL for server-to-server calls |
 | `REDIS_HOST` / `REDIS_PORT` | http/sse (optional) | Token storage (falls back to in-memory) |
 | `PLANE_OAUTH_PROVIDER_*` | http/sse OAuth | OAuth client credentials and base URL |
+| `PLANE_OAUTH_ALLOWED_REDIRECT_URIS` | http/sse OAuth (optional) | Comma-separated redirect URI patterns appended to the built-in allowlist (onboard clients without a release) |
 | `LOG_USER_INFO` | all (optional, default: false) | When `true`, include user info (PII such as display name) in logs alongside the opaque user id |

--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ export PLANE_WORKSPACE_SLUG="your-workspace-slug"
 
 **Note**: For remote HTTP transports (OAuth or PAT), authentication is handled via the connection method (OAuth flow or PAT headers) and does not require these environment variables.
 
+### OAuth redirect URIs
+
+For the OAuth HTTP/SSE transports, the server validates each client's redirect URI against an allowlist. Common MCP clients (Cursor, VS Code, Claude.ai, ChatGPT connectors, localhost) are allowed by default.
+
+To onboard a new client without a code change or release, append extra patterns via an environment variable:
+
+- `PLANE_OAUTH_ALLOWED_REDIRECT_URIS`: Comma-separated redirect URI patterns appended to the built-in allowlist.
+
+```bash
+export PLANE_OAUTH_ALLOWED_REDIRECT_URIS="https://newclient.com/cb,https://other.app/oauth/*"
+```
+
+Patterns support glob matching (`*` matches any port, path segment, or subdomain). For security, keep the host pinned and wildcard only the port/path.
+
 ### Logging
 
 The server emits structured JSON logs. Each tool call is logged with its tool name, duration, status, and (when available) the opaque user id and workspace slug.

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -13,6 +13,40 @@ from plane_mcp.middleware import PlaneLoggingMiddleware
 from plane_mcp.storage import build_token_store
 from plane_mcp.tools import register_tools
 
+# Baseline redirect URIs shipped with the server. Additional patterns can be
+# supplied at runtime via PLANE_OAUTH_ALLOWED_REDIRECT_URIS (comma-separated) so
+# onboarding a new MCP client needs only a config change, not a new release.
+DEFAULT_ALLOWED_REDIRECT_URIS = [
+    # Localhost only for http (dynamic ports from MCP clients)
+    "http://localhost:*",
+    "http://localhost:*/*",
+    "http://127.0.0.1:*",
+    "http://127.0.0.1:*/*",
+    # Known MCP client custom protocol schemes
+    "cursor://anysphere.cursor-mcp/oauth/*",
+    "https://www.cursor.com/*",
+    "https://vscode.dev/redirect",
+    "https://insiders.vscode.dev/redirect",
+    "https://antigravity.google/oauth-callback",
+    # Claude.ai web client
+    "https://claude.ai/*",
+    # ChatGPT connectors — per-connector callback + legacy redirect
+    "https://chatgpt.com/connector/oauth/*",
+    "https://chatgpt.com/connector_platform_oauth_redirect",
+]
+
+
+def get_allowed_client_redirect_uris() -> list[str]:
+    """Return the redirect URI allowlist: built-in defaults plus any extras
+    from the PLANE_OAUTH_ALLOWED_REDIRECT_URIS env var (comma-separated)."""
+    allowed = list(DEFAULT_ALLOWED_REDIRECT_URIS)
+    extra = os.getenv("PLANE_OAUTH_ALLOWED_REDIRECT_URIS", "")
+    for uri in extra.split(","):
+        uri = uri.strip()
+        if uri and uri not in allowed:
+            allowed.append(uri)
+    return allowed
+
 
 def get_oauth_mcp(base_path: str = "/") -> FastMCP:
     """Build the FastMCP instance for the OAuth HTTP / SSE transports."""
@@ -30,24 +64,7 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
             enable_cimd=os.getenv("PLANE_OAUTH_PROVIDER_ENABLE_CIMD", "false").lower() == "true",
             client_storage=build_token_store(),
             required_scopes=["read", "write"],
-            allowed_client_redirect_uris=[
-                # Localhost only for http (dynamic ports from MCP clients)
-                "http://localhost:*",
-                "http://localhost:*/*",
-                "http://127.0.0.1:*",
-                "http://127.0.0.1:*/*",
-                # Known MCP client custom protocol schemes
-                "cursor://anysphere.cursor-mcp/oauth/*",
-                "https://www.cursor.com/*",
-                "https://vscode.dev/redirect",
-                "https://insiders.vscode.dev/redirect",
-                "https://antigravity.google/oauth-callback",
-                # Claude.ai web client
-                "https://claude.ai/*",
-                # ChatGPT connectors — per-connector callback + legacy redirect
-                "https://chatgpt.com/connector/oauth/*",
-                "https://chatgpt.com/connector_platform_oauth_redirect",
-            ],
+            allowed_client_redirect_uris=get_allowed_client_redirect_uris(),
         ),
     )
     oauth_mcp.add_middleware(PlaneLoggingMiddleware(include_payloads=True))


### PR DESCRIPTION
## Description
Adds `PLANE_OAUTH_EXTRA_REDIRECT_URIS` env var. Extra redirect URI patterns are appended to the built-in allowlist at startup.

## Changes
- Extract baseline list to `DEFAULT_ALLOWED_REDIRECT_URIS`
- Add `get_allowed_client_redirect_uris()` — defaults + env extras, comma-separated, trimmed, deduped

## Usage
PLANE_OAUTH_EXTRA_REDIRECT_URIS="https://newclient.com/cb,https://other.app/oauth/*"