### PR TITLE
feat: add initiative project management tools

### DIFF
--- a/plane_mcp/tools/initiatives.py
+++ b/plane_mcp/tools/initiatives.py
@@ -1,6 +1,6 @@
 """Initiative-related tools for Plane MCP Server."""
 
-from typing import Any
+from typing import Any, Literal
 
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
@@ -11,8 +11,13 @@ from plane.models.initiatives import (
     PaginatedInitiativeResponse,
     UpdateInitiative,
 )
+from plane.models.projects import PaginatedProjectResponse, Project
 
 from plane_mcp.client import get_plane_client_context
+
+_PROJECTS_NEED_NATIVE = (
+    "Linking projects to an initiative requires the native initiatives feature. Enable it in workspace settings."
+)
 
 
 def _require_native_initiatives(client: Any, workspace_slug: str, fallback: str) -> None:
@@ -208,3 +213,54 @@ def register_initiative_tools(mcp: FastMCP) -> None:
             "delete_work_item(project_id, work_item_id) instead.",
         )
         client.initiatives.delete(workspace_slug=workspace_slug, initiative_id=initiative_id)
+
+    @mcp.tool()
+    def list_initiative_projects(
+        initiative_id: str,
+        params: dict[str, Any] | None = None,
+    ) -> list[Project]:
+        """
+        List projects linked to an initiative.
+
+        Args:
+            initiative_id: UUID of the initiative
+            params: Optional query parameters (e.g., per_page, cursor)
+
+        Returns:
+            List of linked Project objects
+        """
+        client, workspace_slug = get_plane_client_context()
+        _require_native_initiatives(client, workspace_slug, _PROJECTS_NEED_NATIVE)
+        response: PaginatedProjectResponse = client.initiatives.projects.list(
+            workspace_slug=workspace_slug, initiative_id=initiative_id, params=params
+        )
+        return response.results
+
+    @mcp.tool()
+    def manage_initiative_projects(
+        initiative_id: str,
+        action: Literal["add", "remove"],
+        project_ids: list[str],
+    ) -> list[Project]:
+        """
+        Link or unlink projects of an initiative. Use list_initiative_projects to read.
+
+        Args:
+            initiative_id: UUID of the initiative
+            action: "add" to link the projects, "remove" to unlink them
+            project_ids: Project UUIDs to link/unlink
+
+        Returns:
+            The initiative's linked projects after the operation
+        """
+        client, workspace_slug = get_plane_client_context()
+        _require_native_initiatives(client, workspace_slug, _PROJECTS_NEED_NATIVE)
+
+        if not project_ids:
+            raise ToolError("project_ids must not be empty.")
+        projects = client.initiatives.projects
+        mutate = projects.add if action == "add" else projects.remove
+        mutate(workspace_slug=workspace_slug, initiative_id=initiative_id, project_ids=project_ids)
+
+        response: PaginatedProjectResponse = projects.list(workspace_slug=workspace_slug, initiative_id=initiative_id)
+        return response.results


### PR DESCRIPTION
### Description

Adds MCP tools to manage projects linked to initiatives.

**New tools:**

* `list_initiative_projects` – Lists all projects linked to an initiative.
* `manage_initiative_projects` – Adds or removes project links for an initiative.

### Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Improvement
* [ ] Code refactoring
* [ ] Performance improvements
* [ ] Documentation update

### Test Scenarios

* Verified listing projects linked to an initiative.
* Verified adding projects to an initiative.
* Verified removing projects from an initiative.
* Verified validation for empty `project_ids`.
* Verified appropriate error when native initiatives are unavailable.

### References

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing projects linked to an initiative.
  * Added the ability to add or remove projects from an initiative.
* **Bug Fixes**
  * Improved validation to prevent empty project selections when updating initiative links.
* **Chores**
  * Added clearer guidance when initiative features aren’t available in a workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->