### PR TITLE
feat: add customer management tools

### DIFF
--- a/plane_mcp/tools/__init__.py
+++ b/plane_mcp/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from fastmcp import FastMCP
 
+from plane_mcp.tools.customers import register_customer_tools
 from plane_mcp.tools.cycles import register_cycle_tools
 from plane_mcp.tools.initiatives import register_initiative_tools
 from plane_mcp.tools.intake import register_intake_tools
@@ -51,4 +52,5 @@ def register_tools(mcp: FastMCP) -> None:
     register_workspace_tools(mcp)
     register_milestone_tools(mcp)
     register_role_tools(mcp)
+    register_customer_tools(mcp)
     register_pql_tools(mcp)

--- a/plane_mcp/tools/customers.py
+++ b/plane_mcp/tools/customers.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 from plane.models.customers import (
     CreateCustomer,
     CreateCustomerProperty,
@@ -323,6 +324,12 @@ def register_customer_tools(mcp: FastMCP) -> None:
         validated_relation_type: RelationType | None = None
         if relation_type:
             validated_relation_type = RelationType(relation_type)
+
+        # settings must be paired with property_type — TEXT vs DATETIME settings
+        # can only be built when the type is known. Reject a settings-only update
+        # rather than silently dropping it.
+        if settings and not property_type:
+            raise ToolError("Updating settings requires property_type (TEXT or DATETIME) to be provided as well.")
 
         processed_settings: PropertySettings = None
         if settings and property_type:

--- a/plane_mcp/tools/customers.py
+++ b/plane_mcp/tools/customers.py
@@ -1,0 +1,478 @@
+"""Customer-related tools for Plane MCP Server."""
+
+from typing import Any
+
+from fastmcp import FastMCP
+from plane.models.customers import (
+    CreateCustomer,
+    CreateCustomerProperty,
+    Customer,
+    CustomerProperty,
+    CustomerRequest,
+    PaginatedCustomerPropertyResponse,
+    PaginatedCustomerResponse,
+    UpdateCustomer,
+    UpdateCustomerProperty,
+    UpdateCustomerRequest,
+)
+from plane.models.enums import PropertyType, RelationType
+from plane.models.work_item_properties import PropertySettings
+from plane.models.work_item_property_configurations import (
+    DateAttributeSettings,
+    TextAttributeSettings,
+)
+
+from plane_mcp.client import get_plane_client_context
+
+
+def register_customer_tools(mcp: FastMCP) -> None:
+    """Register all customer-related tools with the MCP server."""
+
+    # --- Customers -----------------------------------------------------------
+
+    @mcp.tool()
+    def list_customers(
+        params: dict[str, Any] | None = None,
+    ) -> list[Customer]:
+        """
+        List all customers in the workspace.
+
+        Args:
+            params: Optional query parameters as a dictionary (e.g., per_page, cursor)
+
+        Returns:
+            List of Customer objects
+        """
+        client, workspace_slug = get_plane_client_context()
+        response: PaginatedCustomerResponse = client.customers.list(workspace_slug=workspace_slug, params=params)
+        return response.results
+
+    @mcp.tool()
+    def create_customer(
+        name: str,
+        description_html: str | None = None,
+        email: str | None = None,
+        website_url: str | None = None,
+        domain: str | None = None,
+        employees: int | None = None,
+        stage: str | None = None,
+        contract_status: str | None = None,
+        revenue: str | None = None,
+        logo_props: dict | None = None,
+    ) -> Customer:
+        """
+        Create a new customer in the workspace.
+
+        Args:
+            name: Customer name
+            description_html: HTML description of the customer
+            email: Primary contact email
+            website_url: Customer website URL
+            domain: Customer domain (e.g. "acme.com")
+            employees: Number of employees
+            stage: Customer lifecycle stage
+            contract_status: Contract status
+            revenue: Customer revenue (string, e.g. "1000000")
+            logo_props: Logo properties dictionary
+
+        Returns:
+            Created Customer object
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = CreateCustomer(
+            name=name,
+            description_html=description_html,
+            email=email,
+            website_url=website_url,
+            domain=domain,
+            employees=employees,
+            stage=stage,
+            contract_status=contract_status,
+            revenue=revenue,
+            logo_props=logo_props,
+        )
+        return client.customers.create(workspace_slug=workspace_slug, data=data)
+
+    @mcp.tool()
+    def retrieve_customer(customer_id: str) -> Customer:
+        """
+        Retrieve a customer by ID.
+
+        Args:
+            customer_id: UUID of the customer
+
+        Returns:
+            Customer object
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.retrieve(workspace_slug=workspace_slug, customer_id=customer_id)
+
+    @mcp.tool()
+    def update_customer(
+        customer_id: str,
+        name: str | None = None,
+        description_html: str | None = None,
+        email: str | None = None,
+        website_url: str | None = None,
+        domain: str | None = None,
+        employees: int | None = None,
+        stage: str | None = None,
+        contract_status: str | None = None,
+        revenue: str | None = None,
+        logo_props: dict | None = None,
+    ) -> Customer:
+        """
+        Update a customer by ID.
+
+        Args:
+            customer_id: UUID of the customer
+            name: Customer name
+            description_html: HTML description of the customer
+            email: Primary contact email
+            website_url: Customer website URL
+            domain: Customer domain (e.g. "acme.com")
+            employees: Number of employees
+            stage: Customer lifecycle stage
+            contract_status: Contract status
+            revenue: Customer revenue (string, e.g. "1000000")
+            logo_props: Logo properties dictionary
+
+        Returns:
+            Updated Customer object
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = UpdateCustomer(
+            name=name,
+            description_html=description_html,
+            email=email,
+            website_url=website_url,
+            domain=domain,
+            employees=employees,
+            stage=stage,
+            contract_status=contract_status,
+            revenue=revenue,
+            logo_props=logo_props,
+        )
+        return client.customers.update(workspace_slug=workspace_slug, customer_id=customer_id, data=data)
+
+    @mcp.tool()
+    def delete_customer(customer_id: str) -> None:
+        """
+        Delete a customer by ID.
+
+        Args:
+            customer_id: UUID of the customer
+        """
+        client, workspace_slug = get_plane_client_context()
+        client.customers.delete(workspace_slug=workspace_slug, customer_id=customer_id)
+
+    # --- Customer properties -------------------------------------------------
+
+    @mcp.tool()
+    def list_customer_properties(
+        params: dict[str, Any] | None = None,
+    ) -> list[CustomerProperty]:
+        """
+        List all customer properties in the workspace.
+
+        Customer properties are custom fields defined at the workspace level and
+        applied to every customer.
+
+        Args:
+            params: Optional query parameters as a dictionary (e.g., per_page, cursor)
+
+        Returns:
+            List of CustomerProperty objects
+        """
+        client, workspace_slug = get_plane_client_context()
+        response: PaginatedCustomerPropertyResponse = client.customers.properties.list(
+            workspace_slug=workspace_slug, params=params
+        )
+        return response.results
+
+    @mcp.tool()
+    def create_customer_property(
+        name: str,
+        display_name: str,
+        property_type: str,
+        relation_type: str | None = None,
+        description: str | None = None,
+        is_required: bool | None = None,
+        default_value: list[str] | None = None,
+        settings: dict | None = None,
+        is_active: bool | None = None,
+        is_multi: bool | None = None,
+        validation_rules: dict | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
+    ) -> CustomerProperty:
+        """
+        Create a new customer property (custom field on customers).
+
+        Args:
+            name: Internal name for the property
+            display_name: User-facing label for the property
+            property_type: TEXT | DATETIME | DECIMAL | BOOLEAN | OPTION | RELATION | URL | EMAIL | FILE | FORMULA
+            relation_type: ISSUE | USER — required when property_type=RELATION
+            description: Property description
+            is_required: Whether the property is required
+            default_value: Default value(s) for the property
+            settings: Required for TEXT/DATETIME.
+                TEXT:     {"display_format": "single-line"|"multi-line"|"readonly"}
+                DATETIME: {"display_format": "MMM dd, yyyy"|"dd/MM/yyyy"|"MM/dd/yyyy"|"yyyy/MM/dd"}
+            is_active: Whether the property is active
+            is_multi: Whether the property supports multiple values
+            validation_rules: Validation rules dictionary
+            external_source: External system source name
+            external_id: External system identifier
+
+        Returns:
+            Created CustomerProperty object
+        """
+        client, workspace_slug = get_plane_client_context()
+
+        validated_property_type = PropertyType(property_type)
+
+        validated_relation_type: RelationType | None = None
+        if relation_type:
+            validated_relation_type = RelationType(relation_type)
+
+        processed_settings: PropertySettings = None
+        if settings:
+            if property_type == "TEXT":
+                processed_settings = TextAttributeSettings(**settings)
+            elif property_type == "DATETIME":
+                processed_settings = DateAttributeSettings(**settings)
+
+        data = CreateCustomerProperty(
+            name=name,
+            display_name=display_name,
+            property_type=validated_property_type,
+            relation_type=validated_relation_type,
+            description=description,
+            is_required=is_required,
+            default_value=default_value,
+            settings=processed_settings,
+            is_active=is_active,
+            is_multi=is_multi,
+            validation_rules=validation_rules,
+            external_source=external_source,
+            external_id=external_id,
+        )
+        return client.customers.properties.create(workspace_slug=workspace_slug, data=data)
+
+    @mcp.tool()
+    def retrieve_customer_property(property_id: str) -> CustomerProperty:
+        """
+        Retrieve a customer property by ID.
+
+        Args:
+            property_id: UUID of the customer property
+
+        Returns:
+            CustomerProperty object
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.properties.retrieve(workspace_slug=workspace_slug, property_id=property_id)
+
+    @mcp.tool()
+    def update_customer_property(
+        property_id: str,
+        display_name: str | None = None,
+        property_type: str | None = None,
+        relation_type: str | None = None,
+        description: str | None = None,
+        is_required: bool | None = None,
+        default_value: list[str] | None = None,
+        settings: dict | None = None,
+        is_active: bool | None = None,
+        is_multi: bool | None = None,
+        validation_rules: dict | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
+    ) -> CustomerProperty:
+        """
+        Update a customer property by ID.
+
+        Args:
+            property_id: UUID of the customer property
+            display_name: User-facing label for the property
+            property_type: TEXT | DATETIME | DECIMAL | BOOLEAN | OPTION | RELATION | URL | EMAIL | FILE | FORMULA
+            relation_type: ISSUE | USER — required when updating to RELATION
+            description: Property description
+            is_required: Whether the property is required
+            default_value: Default value(s) for the property
+            settings: Required when changing type to TEXT/DATETIME.
+                TEXT:     {"display_format": "single-line"|"multi-line"|"readonly"}
+                DATETIME: {"display_format": "MMM dd, yyyy"|"dd/MM/yyyy"|"MM/dd/yyyy"|"yyyy/MM/dd"}
+            is_active: Whether the property is active
+            is_multi: Whether the property supports multiple values
+            validation_rules: Validation rules dictionary
+            external_source: External system source name
+            external_id: External system identifier
+
+        Returns:
+            Updated CustomerProperty object
+        """
+        client, workspace_slug = get_plane_client_context()
+
+        validated_property_type: PropertyType | None = None
+        if property_type:
+            validated_property_type = PropertyType(property_type)
+
+        validated_relation_type: RelationType | None = None
+        if relation_type:
+            validated_relation_type = RelationType(relation_type)
+
+        processed_settings: PropertySettings = None
+        if settings and property_type:
+            if property_type == "TEXT":
+                processed_settings = TextAttributeSettings(**settings)
+            elif property_type == "DATETIME":
+                processed_settings = DateAttributeSettings(**settings)
+
+        data = UpdateCustomerProperty(
+            display_name=display_name,
+            property_type=validated_property_type,
+            relation_type=validated_relation_type,
+            description=description,
+            is_required=is_required,
+            default_value=default_value,
+            settings=processed_settings,
+            is_active=is_active,
+            is_multi=is_multi,
+            validation_rules=validation_rules,
+            external_source=external_source,
+            external_id=external_id,
+        )
+        return client.customers.properties.update(workspace_slug=workspace_slug, property_id=property_id, data=data)
+
+    @mcp.tool()
+    def delete_customer_property(property_id: str) -> None:
+        """
+        Delete a customer property by ID.
+
+        Args:
+            property_id: UUID of the customer property
+        """
+        client, workspace_slug = get_plane_client_context()
+        client.customers.properties.delete(workspace_slug=workspace_slug, property_id=property_id)
+
+    # --- Customer requests ---------------------------------------------------
+
+    @mcp.tool()
+    def list_customer_requests(
+        customer_id: str,
+        params: dict[str, Any] | None = None,
+    ) -> list[CustomerRequest]:
+        """
+        List all requests belonging to a customer.
+
+        A customer request captures a customer's ask and can reference the work
+        items that address it via `work_item_ids`.
+
+        Args:
+            customer_id: UUID of the customer
+            params: Optional query parameters as a dictionary (e.g., per_page, cursor)
+
+        Returns:
+            List of CustomerRequest objects
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.requests.list(workspace_slug=workspace_slug, customer_id=customer_id, params=params)
+
+    @mcp.tool()
+    def create_customer_request(
+        customer_id: str,
+        name: str,
+        description_html: str | None = None,
+        link: str | None = None,
+        work_item_ids: list[str] | None = None,
+    ) -> CustomerRequest:
+        """
+        Create a request for a customer.
+
+        Args:
+            customer_id: UUID of the customer
+            name: Request name
+            description_html: HTML description of the request
+            link: Optional URL associated with the request
+            work_item_ids: UUIDs of work items that address this request
+
+        Returns:
+            Created CustomerRequest object
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = CustomerRequest(
+            name=name,
+            description_html=description_html,
+            link=link,
+            work_item_ids=work_item_ids,
+        )
+        return client.customers.requests.create(workspace_slug=workspace_slug, customer_id=customer_id, data=data)
+
+    @mcp.tool()
+    def retrieve_customer_request(customer_id: str, request_id: str) -> CustomerRequest:
+        """
+        Retrieve a customer request by ID.
+
+        Args:
+            customer_id: UUID of the customer
+            request_id: UUID of the customer request
+
+        Returns:
+            CustomerRequest object
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.requests.retrieve(
+            workspace_slug=workspace_slug, customer_id=customer_id, request_id=request_id
+        )
+
+    @mcp.tool()
+    def update_customer_request(
+        customer_id: str,
+        request_id: str,
+        name: str | None = None,
+        description_html: str | None = None,
+        link: str | None = None,
+        work_item_ids: list[str] | None = None,
+    ) -> CustomerRequest:
+        """
+        Update a customer request by ID.
+
+        Args:
+            customer_id: UUID of the customer
+            request_id: UUID of the customer request
+            name: Request name
+            description_html: HTML description of the request
+            link: Optional URL associated with the request
+            work_item_ids: UUIDs of work items that address this request
+
+        Returns:
+            Updated CustomerRequest object
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = UpdateCustomerRequest(
+            name=name,
+            description_html=description_html,
+            link=link,
+            work_item_ids=work_item_ids,
+        )
+        return client.customers.requests.update(
+            workspace_slug=workspace_slug,
+            customer_id=customer_id,
+            request_id=request_id,
+            data=data,
+        )
+
+    @mcp.tool()
+    def delete_customer_request(customer_id: str, request_id: str) -> None:
+        """
+        Delete a customer request by ID.
+
+        Args:
+            customer_id: UUID of the customer
+            request_id: UUID of the customer request
+        """
+        client, workspace_slug = get_plane_client_context()
+        client.customers.requests.delete(workspace_slug=workspace_slug, customer_id=customer_id, request_id=request_id)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -372,6 +372,24 @@ EXPECTED_TOOLS = [
     "retrieve_work_item_property",
     "update_work_item_property",
     "delete_work_item_property",
+    # Customer tools
+    "list_customers",
+    "create_customer",
+    "retrieve_customer",
+    "update_customer",
+    "delete_customer",
+    # Customer property tools
+    "list_customer_properties",
+    "create_customer_property",
+    "retrieve_customer_property",
+    "update_customer_property",
+    "delete_customer_property",
+    # Customer request tools
+    "list_customer_requests",
+    "create_customer_request",
+    "retrieve_customer_request",
+    "update_customer_request",
+    "delete_customer_request",
 ]
 
 
@@ -416,5 +434,192 @@ def test_tools_availability():
     asyncio.run(run_tools_availability_test())
 
 
+async def run_customer_integration_test():
+    """
+    Full customer integration test:
+    1. Create a customer
+    2. Retrieve the customer
+    3. Update the customer
+    4. List customers and confirm the created customer is present
+    5. Create a workspace-level customer property (TEXT)
+    6. List customer properties and confirm the created property is present
+    7. Update the customer property
+    8. Create a project and a work item to associate with a request
+    9. Create a customer request referencing the work item
+    10. List the customer's requests and confirm the created request is present
+    11. Retrieve the request
+    12. Update the request
+    13. Delete the request
+    14. Delete the customer property
+    15. Delete the work item and project
+    16. Delete the customer
+    """
+    config = get_config()
+    unique_id = uuid.uuid4().hex[:6]
+
+    transport = StreamableHttpTransport(
+        f"{config['mcp_url']}/http/api-key/mcp",
+        headers={
+            "x-workspace-slug": config["workspace_slug"],
+            "authorization": f"Bearer {config['api_key']}",
+        },
+    )
+
+    async with Client(transport=transport) as client:
+        # 1. Create customer
+        print("Creating customer...")
+        customer_result = await client.call_tool(
+            "create_customer",
+            {
+                "name": f"Test Customer {unique_id}",
+                "domain": f"test-{unique_id}.example.com",
+                "email": f"contact-{unique_id}@example.com",
+                "employees": 42,
+            },
+        )
+        customer = extract_result(customer_result)
+        customer_id = customer["id"]
+        print(f"Created customer: {customer_id}")
+
+        # 2. Retrieve customer
+        print("Retrieving customer...")
+        retrieved = extract_result(await client.call_tool("retrieve_customer", {"customer_id": customer_id}))
+        assert retrieved["id"] == customer_id
+
+        # 3. Update customer
+        print("Updating customer...")
+        updated = extract_result(
+            await client.call_tool(
+                "update_customer",
+                {"customer_id": customer_id, "name": f"Updated Customer {unique_id}"},
+            )
+        )
+        assert updated["name"] == f"Updated Customer {unique_id}"
+
+        # 4. List customers and confirm presence
+        print("Listing customers...")
+        customers = extract_result(await client.call_tool("list_customers", {}))
+        customer_ids = [c["id"] for c in customers]
+        assert customer_id in customer_ids, "created customer not found in list"
+
+        # 5. Create a customer property (TEXT)
+        print("Creating customer property...")
+        property_result = await client.call_tool(
+            "create_customer_property",
+            {
+                "name": f"tier_{unique_id}",
+                "display_name": f"Tier {unique_id}",
+                "property_type": "TEXT",
+                "settings": {"display_format": "single-line"},
+            },
+        )
+        customer_property = extract_result(property_result)
+        property_id = customer_property["id"]
+        print(f"Created customer property: {property_id}")
+
+        # 6. List customer properties and confirm presence
+        print("Listing customer properties...")
+        properties = extract_result(await client.call_tool("list_customer_properties", {}))
+        assert property_id in [p["id"] for p in properties], "created property not found in list"
+
+        # 7. Update the customer property
+        print("Updating customer property...")
+        await client.call_tool(
+            "update_customer_property",
+            {"property_id": property_id, "display_name": f"Updated Tier {unique_id}"},
+        )
+
+        # 8. Create a project and work item to associate with a request
+        print("Creating project and work item for request association...")
+        project = extract_result(
+            await client.call_tool(
+                "create_project",
+                {
+                    "name": f"Customer Test Project {unique_id}",
+                    "identifier": f"CT{unique_id[:3].upper()}",
+                },
+            )
+        )
+        project_id = project["id"]
+        work_item = extract_result(
+            await client.call_tool(
+                "create_work_item",
+                {"project_id": project_id, "name": f"Customer Request Work Item {unique_id}"},
+            )
+        )
+        work_item_id = work_item["id"]
+
+        # 9. Create a customer request referencing the work item
+        print("Creating customer request...")
+        request_result = await client.call_tool(
+            "create_customer_request",
+            {
+                "customer_id": customer_id,
+                "name": f"Feature Request {unique_id}",
+                "description_html": "<p>Integration test customer request</p>",
+                "work_item_ids": [work_item_id],
+            },
+        )
+        customer_request = extract_result(request_result)
+        request_id = customer_request["id"]
+        print(f"Created customer request: {request_id}")
+
+        # 10. List customer requests and confirm presence
+        print("Listing customer requests...")
+        requests = extract_result(await client.call_tool("list_customer_requests", {"customer_id": customer_id}))
+        assert request_id in [r["id"] for r in requests], "created request not found in list"
+
+        # 11. Retrieve the request
+        print("Retrieving customer request...")
+        retrieved_request = extract_result(
+            await client.call_tool(
+                "retrieve_customer_request",
+                {"customer_id": customer_id, "request_id": request_id},
+            )
+        )
+        assert retrieved_request["id"] == request_id
+
+        # 12. Update the request
+        print("Updating customer request...")
+        await client.call_tool(
+            "update_customer_request",
+            {
+                "customer_id": customer_id,
+                "request_id": request_id,
+                "name": f"Updated Feature Request {unique_id}",
+            },
+        )
+
+        # 13. Delete the request
+        print("Deleting customer request...")
+        await client.call_tool(
+            "delete_customer_request",
+            {"customer_id": customer_id, "request_id": request_id},
+        )
+
+        # 14. Delete the customer property
+        print("Deleting customer property...")
+        await client.call_tool("delete_customer_property", {"property_id": property_id})
+
+        # 15. Delete work item and project
+        print("Deleting work item and project...")
+        await client.call_tool(
+            "delete_work_item", {"project_id": project_id, "work_item_id": work_item_id}
+        )
+        await client.call_tool("delete_project", {"project_id": project_id})
+
+        # 16. Delete the customer
+        print("Deleting customer...")
+        await client.call_tool("delete_customer", {"customer_id": customer_id})
+
+        print("Customer integration test passed!")
+
+
+def test_customer_integration():
+    """Pytest entry point - runs the async customer integration test."""
+    asyncio.run(run_customer_integration_test())
+
+
 if __name__ == "__main__":
     asyncio.run(run_integration_test())
+    asyncio.run(run_customer_integration_test())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -449,10 +449,10 @@ async def run_customer_integration_test():
     10. List the customer's requests and confirm the created request is present
     11. Retrieve the request
     12. Update the request
-    13. Delete the request
-    14. Delete the customer property
-    15. Delete the work item and project
-    16. Delete the customer
+
+    All created resources are torn down in a finally block, in reverse
+    dependency order, so a mid-test failure does not leak data on the live
+    workspace and one cleanup failure does not block the rest.
     """
     config = get_config()
     unique_id = uuid.uuid4().hex[:6]
@@ -465,154 +465,181 @@ async def run_customer_integration_test():
         },
     )
 
+    # Track created resources so teardown can run even if an assertion fails
+    # mid-test. Cleanup happens in the finally block in reverse dependency order.
+    customer_id = None
+    property_id = None
+    project_id = None
+    work_item_id = None
+    request_id = None
+
     async with Client(transport=transport) as client:
-        # 1. Create customer
-        print("Creating customer...")
-        customer_result = await client.call_tool(
-            "create_customer",
-            {
-                "name": f"Test Customer {unique_id}",
-                "domain": f"test-{unique_id}.example.com",
-                "email": f"contact-{unique_id}@example.com",
-                "employees": 42,
-            },
-        )
-        customer = extract_result(customer_result)
-        customer_id = customer["id"]
-        print(f"Created customer: {customer_id}")
 
-        # 2. Retrieve customer
-        print("Retrieving customer...")
-        retrieved = extract_result(await client.call_tool("retrieve_customer", {"customer_id": customer_id}))
-        assert retrieved["id"] == customer_id
+        async def safe_delete(description, tool, args):
+            """Delete a resource, logging but not raising on failure."""
+            try:
+                await client.call_tool(tool, args)
+            except Exception as exc:  # noqa: BLE001 - teardown must be best-effort
+                print(f"Cleanup warning: failed to delete {description}: {exc}")
 
-        # 3. Update customer
-        print("Updating customer...")
-        updated = extract_result(
-            await client.call_tool(
-                "update_customer",
-                {"customer_id": customer_id, "name": f"Updated Customer {unique_id}"},
-            )
-        )
-        assert updated["name"] == f"Updated Customer {unique_id}"
-
-        # 4. List customers and confirm presence
-        print("Listing customers...")
-        customers = extract_result(await client.call_tool("list_customers", {}))
-        customer_ids = [c["id"] for c in customers]
-        assert customer_id in customer_ids, "created customer not found in list"
-
-        # 5. Create a customer property (TEXT)
-        print("Creating customer property...")
-        property_result = await client.call_tool(
-            "create_customer_property",
-            {
-                "name": f"tier_{unique_id}",
-                "display_name": f"Tier {unique_id}",
-                "property_type": "TEXT",
-                "settings": {"display_format": "single-line"},
-            },
-        )
-        customer_property = extract_result(property_result)
-        property_id = customer_property["id"]
-        print(f"Created customer property: {property_id}")
-
-        # 6. List customer properties and confirm presence
-        print("Listing customer properties...")
-        properties = extract_result(await client.call_tool("list_customer_properties", {}))
-        assert property_id in [p["id"] for p in properties], "created property not found in list"
-
-        # 7. Update the customer property
-        print("Updating customer property...")
-        await client.call_tool(
-            "update_customer_property",
-            {"property_id": property_id, "display_name": f"Updated Tier {unique_id}"},
-        )
-
-        # 8. Create a project and work item to associate with a request
-        print("Creating project and work item for request association...")
-        project = extract_result(
-            await client.call_tool(
-                "create_project",
+        try:
+            # 1. Create customer
+            print("Creating customer...")
+            customer_result = await client.call_tool(
+                "create_customer",
                 {
-                    "name": f"Customer Test Project {unique_id}",
-                    "identifier": f"CT{unique_id[:3].upper()}",
+                    "name": f"Test Customer {unique_id}",
+                    "domain": f"test-{unique_id}.example.com",
+                    "email": f"contact-{unique_id}@example.com",
+                    "employees": 42,
                 },
             )
-        )
-        project_id = project["id"]
-        work_item = extract_result(
-            await client.call_tool(
-                "create_work_item",
-                {"project_id": project_id, "name": f"Customer Request Work Item {unique_id}"},
+            customer = extract_result(customer_result)
+            customer_id = customer["id"]
+            print(f"Created customer: {customer_id}")
+
+            # 2. Retrieve customer
+            print("Retrieving customer...")
+            retrieved = extract_result(await client.call_tool("retrieve_customer", {"customer_id": customer_id}))
+            assert retrieved["id"] == customer_id
+
+            # 3. Update customer
+            print("Updating customer...")
+            updated = extract_result(
+                await client.call_tool(
+                    "update_customer",
+                    {"customer_id": customer_id, "name": f"Updated Customer {unique_id}"},
+                )
             )
-        )
-        work_item_id = work_item["id"]
+            assert updated["name"] == f"Updated Customer {unique_id}"
 
-        # 9. Create a customer request referencing the work item
-        print("Creating customer request...")
-        request_result = await client.call_tool(
-            "create_customer_request",
-            {
-                "customer_id": customer_id,
-                "name": f"Feature Request {unique_id}",
-                "description_html": "<p>Integration test customer request</p>",
-                "work_item_ids": [work_item_id],
-            },
-        )
-        customer_request = extract_result(request_result)
-        request_id = customer_request["id"]
-        print(f"Created customer request: {request_id}")
+            # 4. List customers and confirm presence
+            print("Listing customers...")
+            customers = extract_result(await client.call_tool("list_customers", {}))
+            customer_ids = [c["id"] for c in customers]
+            assert customer_id in customer_ids, "created customer not found in list"
 
-        # 10. List customer requests and confirm presence
-        print("Listing customer requests...")
-        requests = extract_result(await client.call_tool("list_customer_requests", {"customer_id": customer_id}))
-        assert request_id in [r["id"] for r in requests], "created request not found in list"
-
-        # 11. Retrieve the request
-        print("Retrieving customer request...")
-        retrieved_request = extract_result(
-            await client.call_tool(
-                "retrieve_customer_request",
-                {"customer_id": customer_id, "request_id": request_id},
+            # 5. Create a customer property (TEXT)
+            print("Creating customer property...")
+            property_result = await client.call_tool(
+                "create_customer_property",
+                {
+                    "name": f"tier_{unique_id}",
+                    "display_name": f"Tier {unique_id}",
+                    "property_type": "TEXT",
+                    "settings": {"display_format": "single-line"},
+                },
             )
-        )
-        assert retrieved_request["id"] == request_id
+            customer_property = extract_result(property_result)
+            property_id = customer_property["id"]
+            print(f"Created customer property: {property_id}")
 
-        # 12. Update the request
-        print("Updating customer request...")
-        await client.call_tool(
-            "update_customer_request",
-            {
-                "customer_id": customer_id,
-                "request_id": request_id,
-                "name": f"Updated Feature Request {unique_id}",
-            },
-        )
+            # 6. List customer properties and confirm presence
+            print("Listing customer properties...")
+            properties = extract_result(await client.call_tool("list_customer_properties", {}))
+            assert property_id in [p["id"] for p in properties], "created property not found in list"
 
-        # 13. Delete the request
-        print("Deleting customer request...")
-        await client.call_tool(
-            "delete_customer_request",
-            {"customer_id": customer_id, "request_id": request_id},
-        )
+            # 7. Update the customer property
+            print("Updating customer property...")
+            updated_property = extract_result(
+                await client.call_tool(
+                    "update_customer_property",
+                    {"property_id": property_id, "display_name": f"Updated Tier {unique_id}"},
+                )
+            )
+            assert updated_property["display_name"] == f"Updated Tier {unique_id}"
 
-        # 14. Delete the customer property
-        print("Deleting customer property...")
-        await client.call_tool("delete_customer_property", {"property_id": property_id})
+            # 8. Create a project and work item to associate with a request
+            print("Creating project and work item for request association...")
+            project = extract_result(
+                await client.call_tool(
+                    "create_project",
+                    {
+                        "name": f"Customer Test Project {unique_id}",
+                        "identifier": f"CT{unique_id[:3].upper()}",
+                    },
+                )
+            )
+            project_id = project["id"]
+            work_item = extract_result(
+                await client.call_tool(
+                    "create_work_item",
+                    {"project_id": project_id, "name": f"Customer Request Work Item {unique_id}"},
+                )
+            )
+            work_item_id = work_item["id"]
 
-        # 15. Delete work item and project
-        print("Deleting work item and project...")
-        await client.call_tool(
-            "delete_work_item", {"project_id": project_id, "work_item_id": work_item_id}
-        )
-        await client.call_tool("delete_project", {"project_id": project_id})
+            # 9. Create a customer request referencing the work item
+            print("Creating customer request...")
+            request_result = await client.call_tool(
+                "create_customer_request",
+                {
+                    "customer_id": customer_id,
+                    "name": f"Feature Request {unique_id}",
+                    "description_html": "<p>Integration test customer request</p>",
+                    "work_item_ids": [work_item_id],
+                },
+            )
+            customer_request = extract_result(request_result)
+            request_id = customer_request["id"]
+            print(f"Created customer request: {request_id}")
 
-        # 16. Delete the customer
-        print("Deleting customer...")
-        await client.call_tool("delete_customer", {"customer_id": customer_id})
+            # 10. List customer requests and confirm presence
+            print("Listing customer requests...")
+            requests = extract_result(await client.call_tool("list_customer_requests", {"customer_id": customer_id}))
+            assert request_id in [r["id"] for r in requests], "created request not found in list"
 
-        print("Customer integration test passed!")
+            # 11. Retrieve the request
+            print("Retrieving customer request...")
+            retrieved_request = extract_result(
+                await client.call_tool(
+                    "retrieve_customer_request",
+                    {"customer_id": customer_id, "request_id": request_id},
+                )
+            )
+            assert retrieved_request["id"] == request_id
+
+            # 12. Update the request
+            print("Updating customer request...")
+            updated_request = extract_result(
+                await client.call_tool(
+                    "update_customer_request",
+                    {
+                        "customer_id": customer_id,
+                        "request_id": request_id,
+                        "name": f"Updated Feature Request {unique_id}",
+                    },
+                )
+            )
+            assert updated_request["name"] == f"Updated Feature Request {unique_id}"
+
+            print("Customer integration test passed!")
+        finally:
+            # Teardown in reverse dependency order. Each delete is independent so
+            # one failure does not leak the remaining resources.
+            print("Cleaning up customer test resources...")
+            if request_id and customer_id:
+                await safe_delete(
+                    "customer request",
+                    "delete_customer_request",
+                    {"customer_id": customer_id, "request_id": request_id},
+                )
+            if property_id:
+                await safe_delete(
+                    "customer property",
+                    "delete_customer_property",
+                    {"property_id": property_id},
+                )
+            if work_item_id and project_id:
+                await safe_delete(
+                    "work item",
+                    "delete_work_item",
+                    {"project_id": project_id, "work_item_id": work_item_id},
+                )
+            if project_id:
+                await safe_delete("project", "delete_project", {"project_id": project_id})
+            if customer_id:
+                await safe_delete("customer", "delete_customer", {"customer_id": customer_id})
 
 
 def test_customer_integration():


### PR DESCRIPTION
## Add customer management tools

Adds coverage for Plane's **customers** resource, which the server previously had no tools for. Implemented as a new `plane_mcp/tools/customers.py` module following the existing `register_*_tools(mcp)` pattern and using the `plane-sdk` client the same way the other tool modules do.

### What's included

**Customers** (`client.customers`)
- `list_customers`, `create_customer`, `retrieve_customer`, `update_customer`, `delete_customer`

**Customer properties** (workspace-level custom fields, `client.customers.properties`)
- `list_customer_properties`, `create_customer_property`, `retrieve_customer_property`, `update_customer_property`, `delete_customer_property`
- Reuses the existing `TextAttributeSettings` / `DateAttributeSettings` handling for TEXT/DATETIME types and `relation_type` for RELATION, matching `work_item_properties.py`.

**Customer requests** (per-customer, carry `work_item_ids`, `client.customers.requests`)
- `list_customer_requests`, `create_customer_request`, `retrieve_customer_request`, `update_customer_request`, `delete_customer_request`

### Wiring & tests
- Registered `register_customer_tools` in `plane_mcp/tools/__init__.py`.
- Added a full customer-lifecycle integration test (`test_customer_integration`) matching the style in `tests/test_integration.py`: create, retrieve, update, and list a customer; create/list/update/delete a customer property; create a project and work item, then create/list/retrieve/update/delete a customer request that references the work item; full teardown.
- Added all 15 new tools to the `EXPECTED_TOOLS` availability check.

### Verification
- `ruff check` and `ruff format` pass on the new code.
- Full tool set imports and registers cleanly; the offline suites (`test_stateless_http`, `test_oauth_security`, `test_aws_secrets`), which build the server with all tools registered, pass.
- The live integration tests require a Plane instance (`.env.test.local`).

### Follow-up needing direction: customer to work-item link/unlink
Plane's REST API exposes dedicated customer work-item endpoints:
- `POST /customers/{id}/work-items` (link)
- `GET /customers/{id}/work-items` (list)
- `DELETE /customers/{id}/work-items/{work-item-id}` (unlink)

However, **`plane-sdk` has no typed methods for these** (confirmed absent in the pinned `0.2.19` and on the SDK's `main`). Every tool in this repo calls a typed SDK method and returns a Pydantic model, so these three are deliberately left out of this PR rather than reaching into the client's raw HTTP layer and returning untyped JSON. Work items can currently be associated through a customer request's `work_item_ids`.

Options for a follow-up:
1. Add the link/unlink/list tools via the SDK client's HTTP layer (returning raw JSON) as an interim measure.
2. Wait for `plane-sdk` to expose typed methods, then add them in the standard pattern.
3. Upstream the endpoints to `plane-sdk` first, then wire them here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customer management tools, including create, retrieve, update, delete, and list operations.
  * Added customer property management with support for property types, relationships, and settings.
  * Added customer request management linked to work items.
  * Customer lists and related records now return API results consistently.

* **Bug Fixes**
  * Prevented customer property updates that provide settings without a property type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->