### PR TITLE
 feat: add customer tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Three factory functions (`get_oauth_mcp`, `get_header_mcp`, `get_stdio_mcp`) eac
 
 ### Tools (`tools/`)
 
-19 tool modules organized by Plane domain (projects, work_items, cycles, modules, etc.), totaling 55+ tools. Each module exports a `register_*_tools(mcp: FastMCP)` function called from `tools/__init__.py`.
+24 tool modules organized by Plane domain (projects, work_items, cycles, modules, customers, etc.), totaling 150+ tools. Each module exports a `register_*_tools(mcp: FastMCP)` function called from `tools/__init__.py`.
 
 **Tool pattern:**
 ```python

--- a/plane_mcp/tools/__init__.py
+++ b/plane_mcp/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from fastmcp import FastMCP
 
+from plane_mcp.tools.customers import register_customer_tools
 from plane_mcp.tools.cycles import register_cycle_tools
 from plane_mcp.tools.initiatives import register_initiative_tools
 from plane_mcp.tools.intake import register_intake_tools
@@ -51,4 +52,5 @@ def register_tools(mcp: FastMCP) -> None:
     register_workspace_tools(mcp)
     register_milestone_tools(mcp)
     register_role_tools(mcp)
+    register_customer_tools(mcp)
     register_pql_tools(mcp)

--- a/plane_mcp/tools/customers/__init__.py
+++ b/plane_mcp/tools/customers/__init__.py
@@ -1,0 +1,20 @@
+"""Customer-related tools for Plane MCP Server."""
+
+from fastmcp import FastMCP
+
+from plane_mcp.tools.customers.base import register_customer_base_tools
+from plane_mcp.tools.customers.properties import register_customer_property_tools
+from plane_mcp.tools.customers.property_values import register_customer_property_value_tools
+from plane_mcp.tools.customers.requests import register_customer_request_tools
+from plane_mcp.tools.customers.work_items import register_customer_work_item_tools
+
+__all__ = ["register_customer_tools"]
+
+
+def register_customer_tools(mcp: FastMCP) -> None:
+    """Register all customer-related tools with the MCP server."""
+    register_customer_base_tools(mcp)
+    register_customer_property_tools(mcp)
+    register_customer_property_value_tools(mcp)
+    register_customer_request_tools(mcp)
+    register_customer_work_item_tools(mcp)

--- a/plane_mcp/tools/customers/_helpers.py
+++ b/plane_mcp/tools/customers/_helpers.py
@@ -1,0 +1,32 @@
+"""Shared helpers for the customer tool modules."""
+
+from typing import Any
+
+from plane.models.customers import PropertySettings
+from plane.models.work_item_property_configurations import (
+    DateAttributeSettings,
+    TextAttributeSettings,
+)
+
+
+def page_params(cursor: str | None, per_page: int | None, query: str | None = None) -> dict[str, Any]:
+    """Build query params for a paginated customer endpoint, dropping unset ones."""
+    params: dict[str, Any] = {}
+    if cursor:
+        params["cursor"] = cursor
+    if per_page:
+        params["per_page"] = per_page
+    if query:
+        params["query"] = query
+    return params
+
+
+def build_settings(property_type: str, settings: dict | None) -> PropertySettings:
+    """Turn a raw settings dict into the typed settings model for its property type."""
+    if not settings:
+        return None
+    if property_type == "TEXT":
+        return TextAttributeSettings(**settings)
+    if property_type == "DATETIME":
+        return DateAttributeSettings(**settings)
+    return None

--- a/plane_mcp/tools/customers/base.py
+++ b/plane_mcp/tools/customers/base.py
@@ -1,0 +1,200 @@
+"""Customer tools for Plane MCP Server."""
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from plane.models.customers import (
+    CreateCustomer,
+    Customer,
+    PaginatedCustomerResponse,
+    UpdateCustomer,
+)
+
+from plane_mcp.client import get_plane_client_context
+from plane_mcp.tools.customers._helpers import page_params
+
+
+def register_customer_base_tools(mcp: FastMCP) -> None:
+    """Register the customer CRUD tools with the MCP server."""
+
+    @mcp.tool()
+    def list_customers(
+        query: str | None = None,
+        cursor: str | None = None,
+        per_page: int | None = None,
+    ) -> PaginatedCustomerResponse:
+        """
+        List customers in the workspace (paginated).
+
+        Args:
+            query: Filter to customers whose name contains this text.
+            cursor: Prior response's next_cursor; omit for first page.
+            per_page: Results per page (1-1000, default 1000).
+
+        Returns:
+            Paginated envelope: results + total_count, next_cursor,
+            next_page_results (page again while next_page_results is true).
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.list(workspace_slug=workspace_slug, params=page_params(cursor, per_page, query))
+
+    @mcp.tool()
+    def create_customer(
+        name: str,
+        description_html: str | None = None,
+        email: str | None = None,
+        website_url: str | None = None,
+        domain: str | None = None,
+        employees: int | None = None,
+        stage: str | None = None,
+        contract_status: str | None = None,
+        revenue: str | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
+    ) -> Customer:
+        """
+        Create a customer, or update the existing one it matches (upsert).
+
+        This is an upsert, not a plain create. When external_source and external_id
+        are both given, the customer matching them is updated; otherwise a customer
+        with the same name is updated. A new customer is created only when neither
+        matches — so a repeated call never duplicates.
+
+        Args:
+            name: Name of the person or business; also the match key when no external
+                reference is given
+            description_html: HTML description
+            email: Primary contact email
+            website_url: Customer website, e.g. "https://acme.com"
+            domain: The customer's industry — shown as "Industry" in Plane. Free text,
+                e.g. "Retail", "e-Commerce", "Fintech", "Banking". This is NOT a web
+                domain; the site belongs in website_url.
+            employees: Number of employees, if the customer is a business
+            stage: Lifecycle stage. Stored free-form, but Plane only renders:
+                lead | sales_qualified_lead | contract_negotiation | closed_won | closed_lost
+            contract_status: Stored free-form, but Plane only renders:
+                active | pre_contract | signed | inactive
+            revenue: Annual revenue the customer generates, as a string, e.g. "5000000"
+            external_source: External system the customer came from, e.g. "salesforce"
+            external_id: The customer's ID in that external system
+
+        Returns:
+            The created or updated Customer
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = CreateCustomer(
+            name=name,
+            description_html=description_html,
+            email=email,
+            website_url=website_url,
+            domain=domain,
+            employees=employees,
+            stage=stage,
+            contract_status=contract_status,
+            revenue=revenue,
+            external_source=external_source,
+            external_id=external_id,
+        )
+        return client.customers.create(workspace_slug=workspace_slug, data=data)
+
+    @mcp.tool()
+    def retrieve_customer(customer_id: str) -> Customer:
+        """
+        Retrieve a customer by ID.
+
+        Args:
+            customer_id: UUID of the customer
+
+        Returns:
+            The Customer
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.retrieve(workspace_slug=workspace_slug, customer_id=customer_id)
+
+    @mcp.tool()
+    def update_customer(
+        customer_id: str,
+        name: str | None = None,
+        description_html: str | None = None,
+        email: str | None = None,
+        website_url: str | None = None,
+        domain: str | None = None,
+        employees: int | None = None,
+        stage: str | None = None,
+        contract_status: str | None = None,
+        revenue: str | None = None,
+        logo_props: dict | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
+    ) -> Customer:
+        """
+        Update a customer by ID. Only the fields you pass are changed.
+
+        Args:
+            customer_id: UUID of the customer
+            name: Name of the person or business
+            description_html: HTML description
+            email: Primary contact email
+            website_url: Customer website, e.g. "https://acme.com"
+            domain: The customer's industry — shown as "Industry" in Plane. Free text,
+                e.g. "Retail", "e-Commerce", "Fintech", "Banking". This is NOT a web
+                domain; the site belongs in website_url.
+            employees: Number of employees, if the customer is a business
+            stage: Lifecycle stage. Stored free-form, but Plane only renders:
+                lead | sales_qualified_lead | contract_negotiation | closed_won | closed_lost
+            contract_status: Stored free-form, but Plane only renders:
+                active | pre_contract | signed | inactive
+            revenue: Annual revenue the customer generates, as a string, e.g. "5000000"
+            logo_props: Logo properties
+            external_source: External system the customer came from
+            external_id: The customer's ID in that external system
+
+        Returns:
+            The updated Customer
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = UpdateCustomer(
+            name=name,
+            description_html=description_html,
+            email=email,
+            website_url=website_url,
+            domain=domain,
+            employees=employees,
+            stage=stage,
+            contract_status=contract_status,
+            revenue=revenue,
+            logo_props=logo_props,
+            external_source=external_source,
+            external_id=external_id,
+        )
+        return client.customers.update(workspace_slug=workspace_slug, customer_id=customer_id, data=data)
+
+    @mcp.tool()
+    def delete_customer(
+        customer_id: str | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
+    ) -> None:
+        """
+        Delete a customer, addressed either by ID or by its external reference.
+
+        Pass customer_id, or pass both external_source and external_id for a
+        customer synced from an external system. Deleting by an external reference
+        that matches nothing succeeds silently.
+
+        Args:
+            customer_id: UUID of the customer
+            external_source: External system the customer came from
+            external_id: The customer's ID in that external system
+        """
+        client, workspace_slug = get_plane_client_context()
+        if customer_id:
+            client.customers.delete(workspace_slug=workspace_slug, customer_id=customer_id)
+            return
+        if external_source and external_id:
+            client.customers.delete_by_external_id(
+                workspace_slug=workspace_slug,
+                external_source=external_source,
+                external_id=external_id,
+            )
+            return
+        raise ToolError("Provide customer_id, or both external_source and external_id.")

--- a/plane_mcp/tools/customers/base.py
+++ b/plane_mcp/tools/customers/base.py
@@ -186,15 +186,13 @@ def register_customer_base_tools(mcp: FastMCP) -> None:
             external_source: External system the customer came from
             external_id: The customer's ID in that external system
         """
+        if not customer_id and not (external_source and external_id):
+            raise ToolError("Provide customer_id, or both external_source and external_id.")
+
         client, workspace_slug = get_plane_client_context()
-        if customer_id:
-            client.customers.delete(workspace_slug=workspace_slug, customer_id=customer_id)
-            return
-        if external_source and external_id:
-            client.customers.delete_by_external_id(
-                workspace_slug=workspace_slug,
-                external_source=external_source,
-                external_id=external_id,
-            )
-            return
-        raise ToolError("Provide customer_id, or both external_source and external_id.")
+        client.customers.delete(
+            workspace_slug=workspace_slug,
+            customer_id=customer_id,
+            external_source=external_source,
+            external_id=external_id,
+        )

--- a/plane_mcp/tools/customers/properties.py
+++ b/plane_mcp/tools/customers/properties.py
@@ -52,6 +52,8 @@ def register_customer_property_tools(mcp: FastMCP) -> None:
         is_active: bool | None = None,
         is_multi: bool | None = None,
         options: list[dict] | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
     ) -> CustomerProperty:
         """
         Create a customer property (a workspace-wide custom field on customers).
@@ -75,6 +77,8 @@ def register_customer_property_tools(mcp: FastMCP) -> None:
             is_active: Whether the property is active
             is_multi: Whether the property holds multiple values
             options: For OPTION type — [{"name": str, "description"?: str, "is_default"?: bool}]
+            external_source: External system this property came from, e.g. "salesforce"
+            external_id: The property's ID in that external system
 
         Returns:
             The created CustomerProperty, including its options for OPTION type
@@ -92,6 +96,8 @@ def register_customer_property_tools(mcp: FastMCP) -> None:
             is_active=is_active,
             is_multi=is_multi,
             options=options,
+            external_source=external_source,
+            external_id=external_id,
         )
         return client.customers.properties.create(workspace_slug=workspace_slug, data=data)
 
@@ -119,6 +125,8 @@ def register_customer_property_tools(mcp: FastMCP) -> None:
         default_value: list[str] | None = None,
         is_active: bool | None = None,
         options: list[dict] | None = None,
+        external_source: str | None = None,
+        external_id: str | None = None,
     ) -> CustomerProperty:
         """
         Update a customer property. Only the fields you pass are changed.
@@ -137,6 +145,8 @@ def register_customer_property_tools(mcp: FastMCP) -> None:
             is_active: Whether the property is active
             options: For OPTION type — [{"id": str, ...}] to edit an existing option,
                 or [{"name": str, ...}] without an id to add one
+            external_source: External system this property came from
+            external_id: The property's ID in that external system
 
         Returns:
             The updated CustomerProperty
@@ -150,6 +160,8 @@ def register_customer_property_tools(mcp: FastMCP) -> None:
             default_value=default_value,
             is_active=is_active,
             options=options,
+            external_source=external_source,
+            external_id=external_id,
         )
         return client.customers.properties.update(workspace_slug=workspace_slug, property_id=property_id, data=data)
 

--- a/plane_mcp/tools/customers/properties.py
+++ b/plane_mcp/tools/customers/properties.py
@@ -1,0 +1,165 @@
+"""Customer property tools for Plane MCP Server."""
+
+from fastmcp import FastMCP
+from plane.models.customers import (
+    CreateCustomerProperty,
+    CustomerProperty,
+    PaginatedCustomerPropertyResponse,
+    UpdateCustomerProperty,
+)
+from plane.models.enums import PropertyType, RelationType
+
+from plane_mcp.client import get_plane_client_context
+from plane_mcp.tools.customers._helpers import build_settings, page_params
+
+
+def register_customer_property_tools(mcp: FastMCP) -> None:
+    """Register the customer property tools with the MCP server."""
+
+    @mcp.tool()
+    def list_customer_properties(
+        cursor: str | None = None,
+        per_page: int | None = None,
+    ) -> PaginatedCustomerPropertyResponse:
+        """
+        List customer properties (paginated).
+
+        Customer properties are custom fields defined once per workspace and applied
+        to every customer. Use get_customer_property_values to read what a specific
+        customer holds for them.
+
+        Args:
+            cursor: Prior response's next_cursor; omit for first page.
+            per_page: Results per page (1-1000, default 1000).
+
+        Returns:
+            Paginated envelope: results + total_count, next_cursor,
+            next_page_results (page again while next_page_results is true).
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.properties.list(workspace_slug=workspace_slug, params=page_params(cursor, per_page))
+
+    @mcp.tool()
+    def create_customer_property(
+        name: str,
+        display_name: str,
+        property_type: str,
+        relation_type: str | None = None,
+        description: str | None = None,
+        is_required: bool | None = None,
+        default_value: list[str] | None = None,
+        settings: dict | None = None,
+        is_active: bool | None = None,
+        is_multi: bool | None = None,
+        options: list[dict] | None = None,
+    ) -> CustomerProperty:
+        """
+        Create a customer property (a workspace-wide custom field on customers).
+
+        property_type, is_multi and settings are fixed once created — recreate the
+        property to change them.
+
+        Args:
+            name: Required, but discarded — the stored name is a slug of display_name.
+                Pass display_name here too if you have nothing else.
+            display_name: User-facing label. Must be unique in the workspace: it derives
+                the property's slug, so a display name already in use is rejected.
+            property_type: TEXT | DATETIME | DECIMAL | BOOLEAN | OPTION | RELATION | URL | EMAIL | FILE
+            relation_type: ISSUE | USER — required when property_type=RELATION
+            description: Property description
+            is_required: Whether a value must be set; forces default_value to be empty
+            default_value: Default value(s); at most one unless is_multi
+            settings: Required for TEXT/DATETIME.
+                TEXT:     {"display_format": "single-line"|"multi-line"|"readonly"}
+                DATETIME: {"display_format": "MMM dd, yyyy"|"dd/MM/yyyy"|"MM/dd/yyyy"|"yyyy/MM/dd"}
+            is_active: Whether the property is active
+            is_multi: Whether the property holds multiple values
+            options: For OPTION type — [{"name": str, "description"?: str, "is_default"?: bool}]
+
+        Returns:
+            The created CustomerProperty, including its options for OPTION type
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = CreateCustomerProperty(
+            name=name,
+            display_name=display_name,
+            property_type=PropertyType(property_type),
+            relation_type=RelationType(relation_type) if relation_type else None,
+            description=description,
+            is_required=is_required,
+            default_value=default_value,
+            settings=build_settings(property_type, settings),
+            is_active=is_active,
+            is_multi=is_multi,
+            options=options,
+        )
+        return client.customers.properties.create(workspace_slug=workspace_slug, data=data)
+
+    @mcp.tool()
+    def retrieve_customer_property(property_id: str) -> CustomerProperty:
+        """
+        Retrieve a customer property by ID.
+
+        Args:
+            property_id: UUID of the customer property
+
+        Returns:
+            The CustomerProperty, including its options for OPTION type
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.properties.retrieve(workspace_slug=workspace_slug, property_id=property_id)
+
+    @mcp.tool()
+    def update_customer_property(
+        property_id: str,
+        display_name: str | None = None,
+        relation_type: str | None = None,
+        description: str | None = None,
+        is_required: bool | None = None,
+        default_value: list[str] | None = None,
+        is_active: bool | None = None,
+        options: list[dict] | None = None,
+    ) -> CustomerProperty:
+        """
+        Update a customer property. Only the fields you pass are changed.
+
+        property_type, is_multi and settings cannot be changed after creation — delete
+        and recreate the property instead.
+
+        Args:
+            property_id: UUID of the customer property
+            display_name: User-facing label. Also re-slugs the property's internal name,
+                so it must stay unique in the workspace.
+            relation_type: ISSUE | USER — only for RELATION properties
+            description: Property description
+            is_required: Whether a value must be set; forces default_value to be empty
+            default_value: Default value(s); at most one unless the property is is_multi
+            is_active: Whether the property is active
+            options: For OPTION type — [{"id": str, ...}] to edit an existing option,
+                or [{"name": str, ...}] without an id to add one
+
+        Returns:
+            The updated CustomerProperty
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = UpdateCustomerProperty(
+            display_name=display_name,
+            relation_type=RelationType(relation_type) if relation_type else None,
+            description=description,
+            is_required=is_required,
+            default_value=default_value,
+            is_active=is_active,
+            options=options,
+        )
+        return client.customers.properties.update(workspace_slug=workspace_slug, property_id=property_id, data=data)
+
+    @mcp.tool()
+    def delete_customer_property(property_id: str) -> None:
+        """
+        Delete a customer property, and every customer's values for it.
+
+        Args:
+            property_id: UUID of the customer property
+        """
+        client, workspace_slug = get_plane_client_context()
+        client.customers.properties.delete(workspace_slug=workspace_slug, property_id=property_id)

--- a/plane_mcp/tools/customers/property_values.py
+++ b/plane_mcp/tools/customers/property_values.py
@@ -1,0 +1,61 @@
+"""Customer property value tools for Plane MCP Server."""
+
+from fastmcp import FastMCP
+from plane.models.customers import SetCustomerPropertyValues
+
+from plane_mcp.client import get_plane_client_context
+
+
+def register_customer_property_value_tools(mcp: FastMCP) -> None:
+    """Register the customer property value tools with the MCP server."""
+
+    @mcp.tool()
+    def get_customer_property_values(
+        customer_id: str,
+        property_id: str | None = None,
+    ) -> dict[str, list[str]]:
+        """
+        Read the custom property values a customer holds.
+
+        Args:
+            customer_id: UUID of the customer
+            property_id: UUID of one customer property; omit to read them all
+
+        Returns:
+            Property UUID mapped to its values. Properties with no value set, and
+            inactive properties, are absent.
+        """
+        client, workspace_slug = get_plane_client_context()
+        values = client.customers.property_values
+        if property_id:
+            return {property_id: values.retrieve(workspace_slug, customer_id, property_id)}
+        return values.list(workspace_slug, customer_id)
+
+    @mcp.tool()
+    def set_customer_property_values(
+        customer_id: str,
+        values: dict[str, list[str]],
+    ) -> None:
+        """
+        Set a customer's custom property values, replacing any current ones.
+
+        Only the properties named are touched; the rest keep their values. Every
+        value is a string, whatever the property's type:
+            TEXT/URL/EMAIL/FILE: the text
+            DATETIME: "YYYY-MM-DD"
+            DECIMAL: the number as a string, e.g. "12.5"
+            BOOLEAN: "True" or "False"
+            OPTION/RELATION: the option or related record's UUID
+        Pass a single-item list for properties that are not is_multi.
+
+        Args:
+            customer_id: UUID of the customer
+            values: Property UUID mapped to its new values,
+                e.g. {"<property_id>": ["Enterprise"]}
+        """
+        client, workspace_slug = get_plane_client_context()
+        client.customers.property_values.set(
+            workspace_slug,
+            customer_id,
+            SetCustomerPropertyValues(customer_property_values=values),
+        )

--- a/plane_mcp/tools/customers/property_values.py
+++ b/plane_mcp/tools/customers/property_values.py
@@ -54,7 +54,7 @@ def register_customer_property_value_tools(mcp: FastMCP) -> None:
                 e.g. {"<property_id>": ["Enterprise"]}
         """
         client, workspace_slug = get_plane_client_context()
-        client.customers.property_values.set(
+        client.customers.property_values.create(
             workspace_slug,
             customer_id,
             SetCustomerPropertyValues(customer_property_values=values),

--- a/plane_mcp/tools/customers/requests.py
+++ b/plane_mcp/tools/customers/requests.py
@@ -39,7 +39,7 @@ def register_customer_request_tools(mcp: FastMCP) -> None:
             next_page_results (page again while next_page_results is true).
         """
         client, workspace_slug = get_plane_client_context()
-        return client.customers.requests.list_paginated(
+        return client.customers.requests.list(
             workspace_slug=workspace_slug,
             customer_id=customer_id,
             params=page_params(cursor, per_page, query),

--- a/plane_mcp/tools/customers/requests.py
+++ b/plane_mcp/tools/customers/requests.py
@@ -1,0 +1,141 @@
+"""Customer request tools for Plane MCP Server."""
+
+from fastmcp import FastMCP
+from plane.models.customers import (
+    CreateCustomerRequest,
+    CustomerRequest,
+    PaginatedCustomerRequestResponse,
+    UpdateCustomerRequest,
+)
+
+from plane_mcp.client import get_plane_client_context
+from plane_mcp.tools.customers._helpers import page_params
+
+
+def register_customer_request_tools(mcp: FastMCP) -> None:
+    """Register the customer request tools with the MCP server."""
+
+    @mcp.tool()
+    def list_customer_requests(
+        customer_id: str,
+        query: str | None = None,
+        cursor: str | None = None,
+        per_page: int | None = None,
+    ) -> PaginatedCustomerRequestResponse:
+        """
+        List a customer's requests (paginated).
+
+        A customer request records something the customer asked for. The work items
+        addressing it are read with list_customer_work_items, not from here.
+
+        Args:
+            customer_id: UUID of the customer
+            query: Filter to requests whose name contains this text.
+            cursor: Prior response's next_cursor; omit for first page.
+            per_page: Results per page (1-1000, default 1000).
+
+        Returns:
+            Paginated envelope: results + total_count, next_cursor,
+            next_page_results (page again while next_page_results is true).
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.requests.list_paginated(
+            workspace_slug=workspace_slug,
+            customer_id=customer_id,
+            params=page_params(cursor, per_page, query),
+        )
+
+    @mcp.tool()
+    def create_customer_request(
+        customer_id: str,
+        name: str,
+        description_html: str | None = None,
+        link: str | None = None,
+        work_item_ids: list[str] | None = None,
+    ) -> CustomerRequest:
+        """
+        Create a request on a customer.
+
+        Args:
+            customer_id: UUID of the customer
+            name: Request name
+            description_html: HTML description
+            link: URL associated with the request
+            work_item_ids: UUIDs of work items addressing this request; links them to
+                the customer as the request is created. Only settable here — use
+                manage_customer_work_items to change links afterwards.
+
+        Returns:
+            The created CustomerRequest. work_item_ids is never echoed back; read the
+            links with list_customer_work_items.
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = CreateCustomerRequest(
+            name=name,
+            description_html=description_html,
+            link=link,
+            work_item_ids=work_item_ids,
+        )
+        return client.customers.requests.create(workspace_slug=workspace_slug, customer_id=customer_id, data=data)
+
+    @mcp.tool()
+    def retrieve_customer_request(customer_id: str, request_id: str) -> CustomerRequest:
+        """
+        Retrieve a customer request by ID.
+
+        Args:
+            customer_id: UUID of the customer
+            request_id: UUID of the customer request
+
+        Returns:
+            The CustomerRequest
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.requests.retrieve(
+            workspace_slug=workspace_slug, customer_id=customer_id, request_id=request_id
+        )
+
+    @mcp.tool()
+    def update_customer_request(
+        customer_id: str,
+        request_id: str,
+        name: str | None = None,
+        description_html: str | None = None,
+        link: str | None = None,
+    ) -> CustomerRequest:
+        """
+        Update a customer request. Only the fields you pass are changed.
+
+        Work item links cannot be changed here — use manage_customer_work_items with
+        this request_id as customer_request_id.
+
+        Args:
+            customer_id: UUID of the customer
+            request_id: UUID of the customer request
+            name: Request name
+            description_html: HTML description
+            link: URL associated with the request
+
+        Returns:
+            The updated CustomerRequest
+        """
+        client, workspace_slug = get_plane_client_context()
+        data = UpdateCustomerRequest(name=name, description_html=description_html, link=link)
+        return client.customers.requests.update(
+            workspace_slug=workspace_slug,
+            customer_id=customer_id,
+            request_id=request_id,
+            data=data,
+        )
+
+    @mcp.tool()
+    def delete_customer_request(customer_id: str, request_id: str) -> None:
+        """
+        Delete a customer request, and unlink the work items linked through it.
+
+        Args:
+            customer_id: UUID of the customer
+            request_id: UUID of the customer request
+        """
+        client, workspace_slug = get_plane_client_context()
+        client.customers.requests.delete(workspace_slug=workspace_slug, customer_id=customer_id, request_id=request_id)

--- a/plane_mcp/tools/customers/work_items.py
+++ b/plane_mcp/tools/customers/work_items.py
@@ -64,7 +64,7 @@ def register_customer_work_item_tools(mcp: FastMCP) -> None:
 
         work_items = client.customers.work_items
         if action == "link":
-            work_items.link(
+            work_items.create(
                 workspace_slug=workspace_slug,
                 customer_id=customer_id,
                 data=LinkCustomerWorkItems(work_item_ids=work_item_ids),
@@ -72,7 +72,7 @@ def register_customer_work_item_tools(mcp: FastMCP) -> None:
             )
         else:
             for work_item_id in work_item_ids:
-                work_items.unlink(
+                work_items.delete(
                     workspace_slug=workspace_slug,
                     customer_id=customer_id,
                     work_item_id=work_item_id,

--- a/plane_mcp/tools/customers/work_items.py
+++ b/plane_mcp/tools/customers/work_items.py
@@ -1,0 +1,82 @@
+"""Customer work item link tools for Plane MCP Server."""
+
+from typing import Literal
+
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from plane.models.customers import CustomerWorkItem, LinkCustomerWorkItems
+
+from plane_mcp.client import get_plane_client_context
+
+
+def register_customer_work_item_tools(mcp: FastMCP) -> None:
+    """Register the customer work item link tools with the MCP server."""
+
+    @mcp.tool()
+    def list_customer_work_items(
+        customer_id: str,
+        customer_request_id: str | None = None,
+        search: str | None = None,
+    ) -> list[CustomerWorkItem]:
+        """
+        List the work items linked to a customer. Returns all of them, unpaginated.
+
+        Args:
+            customer_id: UUID of the customer
+            customer_request_id: Only work items linked through this request of the customer
+            search: Filter by work item name, sequence ID, or project identifier
+
+        Returns:
+            The linked work items
+        """
+        client, workspace_slug = get_plane_client_context()
+        return client.customers.work_items.list(
+            workspace_slug=workspace_slug,
+            customer_id=customer_id,
+            customer_request_id=customer_request_id,
+            search=search,
+        )
+
+    @mcp.tool()
+    def manage_customer_work_items(
+        customer_id: str,
+        action: Literal["link", "unlink"],
+        work_item_ids: list[str],
+        customer_request_id: str | None = None,
+    ) -> list[CustomerWorkItem]:
+        """
+        Link or unlink work items on a customer. Use list_customer_work_items to read.
+
+        Args:
+            customer_id: UUID of the customer
+            action: "link" to attach the work items, "unlink" to detach them
+            work_item_ids: Work item UUIDs to link/unlink
+            customer_request_id: Scope the links to this request of the customer. On
+                unlink, omitting it drops every link to the work item, whichever
+                request made it.
+
+        Returns:
+            The customer's linked work items after the operation
+        """
+        client, workspace_slug = get_plane_client_context()
+        if not work_item_ids:
+            raise ToolError("work_item_ids must not be empty.")
+
+        work_items = client.customers.work_items
+        if action == "link":
+            work_items.link(
+                workspace_slug=workspace_slug,
+                customer_id=customer_id,
+                data=LinkCustomerWorkItems(work_item_ids=work_item_ids),
+                customer_request_id=customer_request_id,
+            )
+        else:
+            for work_item_id in work_item_ids:
+                work_items.unlink(
+                    workspace_slug=workspace_slug,
+                    customer_id=customer_id,
+                    work_item_id=work_item_id,
+                    customer_request_id=customer_request_id,
+                )
+
+        return work_items.list(workspace_slug=workspace_slug, customer_id=customer_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["mcp", "plane", "fastmcp", "ai", "automation"]
 
 dependencies = [
     "fastmcp==3.2.0",
-    "plane-sdk==0.2.19",
+    "plane-sdk==0.2.20",
     "py-key-value-aio[redis]>=0.4.4,<0.5.0",
     "mcp==1.26.0",
     "PyJWT>=2.12.0",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -372,6 +372,30 @@ EXPECTED_TOOLS = [
     "retrieve_work_item_property",
     "update_work_item_property",
     "delete_work_item_property",
+    # Customer tools
+    "list_customers",
+    "create_customer",
+    "retrieve_customer",
+    "update_customer",
+    "delete_customer",
+    # Customer property tools
+    "list_customer_properties",
+    "create_customer_property",
+    "retrieve_customer_property",
+    "update_customer_property",
+    "delete_customer_property",
+    # Customer property value tools
+    "get_customer_property_values",
+    "set_customer_property_values",
+    # Customer request tools
+    "list_customer_requests",
+    "create_customer_request",
+    "retrieve_customer_request",
+    "update_customer_request",
+    "delete_customer_request",
+    # Customer work item tools
+    "list_customer_work_items",
+    "manage_customer_work_items",
 ]
 
 


### PR DESCRIPTION
## Description

Adds MCP tools for Plane's customers domain.

## Tools

- **Customers** — list, create, retrieve, update, delete
- **Properties** — list, create, retrieve, update, delete (workspace-level custom fields)
- **Property values** — get, set (a customer's values for those properties)
- **Requests** — list, create, retrieve, update, delete
- **Work items** — list, and link/unlink work items to a customer

Organized as a `plane_mcp/tools/customers/` package.

## Requires

`plane-sdk==0.2.20`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full suite of customer tools for managing customers (create, view, update, delete) and searching via query/pagination.
  * Added customer property tools, including creating/updating/deleting properties and managing property values.
  * Added customer request tools (list, create, view, update, delete).
  * Added customer work-item tools to list and link/unlink work items with request scoping support.
* **Documentation**
  * Updated architecture documentation to reflect expanded tooling coverage.
* **Tests**
  * Expanded tool availability checks to include all new customer-related tools.
* **Chores**
  * Updated the Plane SDK dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->