### PR TITLE
fix: honor sparse fieldsets in work item lists and harden assignee/label read-backs

### DIFF
--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -25,6 +25,20 @@ from plane_mcp.tools.pql_reference import PQL_FIELD_HINT, PQL_FULL_REFERENCE
 logger = get_logger(__name__)
 
 
+def _dump_results(items: Any, fields: str | None) -> list[Any]:
+    """Serialize a page of work items, honoring `fields` as a sparse fieldset."""
+    requested = {name.strip() for name in fields.split(",")} - {""} if fields else None
+
+    def _dump(item: Any) -> Any:
+        if not hasattr(item, "model_dump"):
+            return item
+        if requested:
+            return item.model_dump(include=requested)
+        return item.model_dump()
+
+    return [_dump(item) for item in (items or [])]
+
+
 def _resolve_description_html(description_html: str | None, description_stripped: str | None) -> str | None:
     """Resolve the description_html to persist.
 
@@ -71,14 +85,13 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             per_page: 1-100, default 25.
             cursor: From previous response's next_cursor.
             expand: Comma-separated relations to expand (e.g. assignees,labels,state).
-            fields: Sparse fieldset — id, name, sequence_id, priority, state,
-                project, assignees, labels, type_id, description_html, start_date,
-                target_date, created_at, updated_at, created_by, is_draft. Use
-                `project` (not `project_id`) and `description_html` (there is no
-                `description` field). Any field you omit or misname comes back
-                null — a null here does NOT mean the item lacks that value; it
-                means it was not requested. To read the description, include
-                description_html; for the type, include type_id.
+            fields: Sparse fieldset — the response contains only the fields you
+                name here (plus pagination metadata). Available: id, name,
+                sequence_id, priority, state, project, assignees, labels, type_id,
+                description_html, start_date, target_date, created_at, updated_at,
+                created_by, is_draft. Use `project` (not `project_id`) and
+                `description_html` (there is no `description` field); a misnamed
+                field is simply absent from the result.
             external_id / external_source: Filter by external system.
 
         Returns:
@@ -124,9 +137,7 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             raise
 
         return {
-            "results": [
-                item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])
-            ],
+            "results": _dump_results(response.results, fields),
             "total_count": response.total_count,
             "count": response.count,
             "next_cursor": response.next_cursor,
@@ -593,9 +604,7 @@ def register_work_item_tools(mcp: FastMCP) -> None:
                 }
             raise
         return {
-            "results": [
-                item.model_dump() if hasattr(item, "model_dump") else item for item in (response.results or [])
-            ],
+            "results": _dump_results(response.results, fields),
             "total_count": response.total_count,
             "count": response.count,
             "next_cursor": response.next_cursor,

--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -39,6 +39,16 @@ def _dump_results(items: Any, fields: str | None) -> list[Any]:
     return [_dump(item) for item in (items or [])]
 
 
+def _ids(items: Any) -> list[str]:
+    """Extract ids from assignees/labels that may be bare id strings or objects."""
+    ids: list[str] = []
+    for item in items or []:
+        value = item if isinstance(item, str) else getattr(item, "id", None)
+        if value:
+            ids.append(value)
+    return ids
+
+
 def _resolve_description_html(description_html: str | None, description_stripped: str | None) -> str | None:
     """Resolve the description_html to persist.
 
@@ -501,7 +511,7 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         current = client.work_items.retrieve(
             workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
         )
-        ids = [u.id for u in (current.assignees or []) if u.id]
+        ids = _ids(current.assignees)
         if remove_user_id:
             ids = [uid for uid in ids if uid != remove_user_id]
         if add_user_id and add_user_id not in ids:
@@ -540,7 +550,7 @@ def register_work_item_tools(mcp: FastMCP) -> None:
         current = client.work_items.retrieve(
             workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
         )
-        ids = [lb.id for lb in (current.labels or []) if lb.id]
+        ids = _ids(current.labels)
         if remove_label_id:
             ids = [lid for lid in ids if lid != remove_label_id]
         if add_label_id and add_label_id not in ids:

--- a/tests/test_work_items.py
+++ b/tests/test_work_items.py
@@ -1,0 +1,97 @@
+"""Unit tests for work item tools (offline, monkeypatched client)."""
+
+import asyncio
+
+from fastmcp import Client, FastMCP
+from plane.models.work_items import WorkItem, WorkItemDetail
+
+from plane_mcp.tools import work_items as work_item_tools
+from plane_mcp.tools.work_items import _ids
+
+
+class FakeWorkItems:
+    """Retrieve returns bare-string assignees/labels (the plain-retrieve shape)."""
+
+    def __init__(self):
+        self.updated = None
+
+    def retrieve(self, workspace_slug, project_id, work_item_id):
+        return WorkItemDetail.model_validate(
+            {
+                "id": work_item_id,
+                "name": "X",
+                "assignees": ["existing-user"],
+                "labels": ["existing-label"],
+            }
+        )
+
+    def update(self, workspace_slug, project_id, work_item_id, data):
+        self.updated = data
+        return WorkItem.model_validate({"id": work_item_id, "name": "X"})
+
+
+class FakeClient:
+    def __init__(self):
+        self.work_items = FakeWorkItems()
+
+
+def _call(monkeypatch, client, tool, args):
+    monkeypatch.setattr(work_item_tools, "get_plane_client_context", lambda: (client, "ws"))
+
+    async def run():
+        mcp = FastMCP("test")
+        work_item_tools.register_work_item_tools(mcp)
+        async with Client(mcp) as c:
+            return await c.call_tool(tool, args)
+
+    return asyncio.run(run())
+
+
+def test_ids_handles_bare_strings_and_objects():
+    """_ids extracts ids whether items are UUID strings or objects with .id."""
+    assert _ids(["u-1", "u-2"]) == ["u-1", "u-2"]
+
+    class Obj:
+        def __init__(self, i):
+            self.id = i
+
+    assert _ids([Obj("u-9")]) == ["u-9"]
+    assert _ids(None) == []
+    assert _ids([]) == []
+
+
+def test_manage_assignee_read_back_survives_bare_string_assignees(monkeypatch):
+    """Regression: retrieve returns UUID-string assignees; the read-back must not
+    crash with "'str' object has no attribute 'id'" (issue #98 knock-on)."""
+    client = FakeClient()
+    _call(
+        monkeypatch,
+        client,
+        "manage_work_item_assignee",
+        {"project_id": "p", "work_item_id": "w", "add_user_id": "new-user"},
+    )
+    assert client.work_items.updated.assignees == ["existing-user", "new-user"]
+
+
+def test_manage_label_read_back_survives_bare_string_labels(monkeypatch):
+    """Regression: retrieve returns UUID-string labels; the read-back must not crash."""
+    client = FakeClient()
+    _call(
+        monkeypatch,
+        client,
+        "manage_work_item_label",
+        {"project_id": "p", "work_item_id": "w", "add_label_id": "new-label"},
+    )
+    assert client.work_items.updated.labels == ["existing-label", "new-label"]
+
+
+def test_manage_assignee_remove_bare_string(monkeypatch):
+    """Removing an existing bare-string assignee drops it without touching the rest."""
+    client = FakeClient()
+    _call(
+        monkeypatch,
+        client,
+        "manage_work_item_assignee",
+        {"project_id": "p", "work_item_id": "w", "remove_user_id": "existing-user"},
+    )
+    assert client.work_items.updated.assignees == []


### PR DESCRIPTION
### Description
Two work-item tool fixes:

- **Sparse fieldsets** — `list_work_items` and `list_archived_work_items` now apply the `fields` argument when serializing results, so the response contains only the requested fields (via a shared `_dump_results` helper). Previously `fields` was accepted but ignored on output.
- **Assignee/label read-backs** — `manage_work_item_assignee` and `manage_work_item_label` extract current ids through a new `_ids` helper that handles both object and bare UUID-string shapes returned by `retrieve`. Fixes the `'str' object has no attribute 'id'` crash on API versions where these come back as plain strings.

Adds offline regression tests (monkeypatched client, no live API).

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement

### Test Scenarios
- `pytest tests/test_work_items.py` — `_ids` on strings/objects/None; assignee & label add/remove read-backs survive bare-string retrieve.
- Manual: add/remove assignee and label on a work item that already has both, then retrieve — no crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved work item assignee and label management when data is returned as IDs or objects.
  * Fixed removal of individual assignees without affecting other assignments.
  * Improved sparse field selection when listing active or archived work items.

* **Tests**
  * Added coverage for mixed ID formats and assignee/label updates.
  * Added regression tests for empty and missing field selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->