### PR TITLE
fix: reject unassignable assignees before Plane silently clears the field

### DIFF
--- a/plane_mcp/tools/work_items.py
+++ b/plane_mcp/tools/work_items.py
@@ -49,6 +49,86 @@ def _ids(items: Any) -> list[str]:
     return ids
 
 
+# Plane's project role ladder: guest=5, member=15, admin=20. Only member and
+# above can hold a work item assignment.
+_MEMBER_ROLE = 15
+
+
+def _is_assignable(member: Any) -> bool:
+    """Whether a project member can hold a work item assignment.
+
+    `role` and `is_active` are missing from some deployments' member payloads.
+    Only reject on a field the server actually reported — an unreported role
+    must not disqualify every member.
+    """
+    if getattr(member, "is_active", None) is False:
+        return False
+    role = getattr(member, "role", None)
+    return role is None or role >= _MEMBER_ROLE
+
+
+def _assert_assignable(client: Any, workspace_slug: str, project_id: str, assignees: list[str]) -> None:
+    """Reject assignees Plane would drop, before a write that would clear the field.
+
+    Plane filters unassignable ids out of `assignees` during validation rather
+    than rejecting them, and an update deletes the work item's existing
+    assignees before writing that filtered list. A single unassignable id
+    therefore clears the assignees and still answers 200, so the caller sees a
+    successful write that both failed and destroyed data. Checking first turns
+    it into an error naming the ids that would work.
+
+    Args:
+        client: Plane client.
+        workspace_slug: The workspace slug identifier.
+        project_id: UUID of the project the work item belongs to.
+        assignees: User IDs the caller asked to assign.
+
+    Raises:
+        ValueError: If any id is not an assignable member of the project.
+    """
+    if not assignees:
+        return
+
+    try:
+        members = client.projects.get_members(workspace_slug=workspace_slug, project_id=project_id)
+        known = {str(m.id): m for m in members}
+        assignable = {uid: m for uid, m in known.items() if _is_assignable(m)}
+    # A pre-check must not become a new failure mode: if the lookup is
+    # unavailable or answers in an unexpected shape, let the write proceed
+    # exactly as it did before.
+    except Exception as e:
+        logger.warning("Could not verify assignees against project %s members: %s", project_id, e)
+        return
+
+    rejected = [uid for uid in assignees if uid not in assignable]
+    if not rejected:
+        return
+
+    details = []
+    for uid in rejected:
+        member = known.get(uid)
+        if member is None:
+            details.append(f"{uid} (not a member of this project)")
+        elif getattr(member, "is_active", None) is False:
+            details.append(f"{uid} ({member.email}, project membership is inactive)")
+        else:
+            details.append(f"{uid} ({member.email}, project role {member.role} is below member)")
+
+    roster = sorted(f"{m.email}={uid}" for uid, m in assignable.items())
+    shown = ", ".join(roster[:25]) or "(none)"
+    if len(roster) > 25:
+        shown += f", … and {len(roster) - 25} more"
+
+    raise ValueError(
+        "Plane silently drops assignees it will not accept, and an update clears the work item's "
+        "existing assignees in the process. Rejected: "
+        + "; ".join(details)
+        + ". Only active project members at member role or above can be assigned. "
+        + f"Assignable members of this project: {shown}. "
+        + "Add the user to the project first, or use one of the IDs above."
+    )
+
+
 def _resolve_description_html(description_html: str | None, description_stripped: str | None) -> str | None:
     """Resolve the description_html to persist.
 
@@ -262,6 +342,8 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             priority if priority in get_args(PriorityEnum) else None  # type: ignore[assignment]
         )
 
+        _assert_assignable(client, workspace_slug, project_id, assignees or [])
+
         data = CreateWorkItem(
             name=name,
             assignees=assignees,
@@ -445,6 +527,8 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             priority if priority in get_args(PriorityEnum) else None  # type: ignore[assignment]
         )
 
+        _assert_assignable(client, workspace_slug, project_id, assignees or [])
+
         data = UpdateWorkItem(
             name=name,
             assignees=assignees,
@@ -508,6 +592,12 @@ def register_work_item_tools(mcp: FastMCP) -> None:
             Updated WorkItem object
         """
         client, workspace_slug = get_plane_client_context()
+        # The update below rewrites the whole list, so an unassignable add_user_id
+        # would clear the very assignees this tool exists to preserve. Only the
+        # incoming id is checked: an already-assigned member who has since lost
+        # access must not block a removal.
+        _assert_assignable(client, workspace_slug, project_id, [add_user_id] if add_user_id else [])
+
         current = client.work_items.retrieve(
             workspace_slug=workspace_slug, project_id=project_id, work_item_id=work_item_id
         )

--- a/tests/test_work_items.py
+++ b/tests/test_work_items.py
@@ -114,6 +114,7 @@ def test_manage_assignee_remove_bare_string(monkeypatch):
 # guard has to run before the write.
 
 MEMBER = {"id": "member-1", "email": "member@example.com", "role": 20, "is_active": True}
+AT_THRESHOLD = {"id": "member-2", "email": "member2@example.com", "role": 15, "is_active": True}
 GUEST = {"id": "guest-1", "email": "guest@example.com", "role": 5, "is_active": True}
 INACTIVE = {"id": "inactive-1", "email": "inactive@example.com", "role": 20, "is_active": False}
 BARE = {"id": "bare-1", "email": "bare@example.com"}  # CE omits role/is_active
@@ -173,11 +174,16 @@ def test_unassignable_assignee_is_rejected_before_the_write(monkeypatch, members
     assert client.work_items.updated is None, "the destructive update must not be issued"
 
 
-def test_assignable_member_passes_through(monkeypatch):
-    """The happy path is unchanged: a real member is written as before."""
-    client = MemberAwareClient([MEMBER])
-    _assign(monkeypatch, client, ["member-1"])
-    assert client.work_items.updated.assignees == ["member-1"]
+@pytest.mark.parametrize("member", [MEMBER, AT_THRESHOLD], ids=["above-threshold", "exactly-at-threshold"])
+def test_assignable_member_passes_through(monkeypatch, member):
+    """The happy path is unchanged, including a role sitting exactly on the member floor.
+
+    Plane's cutoff is `role >= 15`, so role 15 is the value that decides whether the
+    comparison is inclusive — an off-by-one there would lock out every plain member.
+    """
+    client = MemberAwareClient([member])
+    _assign(monkeypatch, client, [member["id"]])
+    assert client.work_items.updated.assignees == [member["id"]]
 
 
 def test_members_without_role_are_accepted_on_membership_alone(monkeypatch):

--- a/tests/test_work_items.py
+++ b/tests/test_work_items.py
@@ -2,7 +2,10 @@
 
 import asyncio
 
+import pytest
 from fastmcp import Client, FastMCP
+from fastmcp.exceptions import ToolError
+from plane.models.projects import ProjectMember
 from plane.models.work_items import WorkItem, WorkItemDetail
 
 from plane_mcp.tools import work_items as work_item_tools
@@ -14,6 +17,12 @@ class FakeWorkItems:
 
     def __init__(self):
         self.updated = None
+        self.created = None
+
+    def create(self, workspace_slug, project_id, data):
+        """Record the create so a test can assert it was never issued."""
+        self.created = data
+        return WorkItem.model_validate({"id": "w", "name": data.name})
 
     def retrieve(self, workspace_slug, project_id, work_item_id):
         return WorkItemDetail.model_validate(
@@ -95,3 +104,133 @@ def test_manage_assignee_remove_bare_string(monkeypatch):
         {"project_id": "p", "work_item_id": "w", "remove_user_id": "existing-user"},
     )
     assert client.work_items.updated.assignees == []
+
+
+# --- assignee assignability guard -------------------------------------------
+#
+# Plane filters unassignable ids out of `assignees` during validation instead of
+# rejecting them, then deletes the work item's existing assignees before writing
+# that filtered list. One bad id clears the field and still answers 200, so the
+# guard has to run before the write.
+
+MEMBER = {"id": "member-1", "email": "member@example.com", "role": 20, "is_active": True}
+GUEST = {"id": "guest-1", "email": "guest@example.com", "role": 5, "is_active": True}
+INACTIVE = {"id": "inactive-1", "email": "inactive@example.com", "role": 20, "is_active": False}
+BARE = {"id": "bare-1", "email": "bare@example.com"}  # CE omits role/is_active
+
+
+class FakeProjects:
+    """`get_members` returns a bare list, the shape the non-lite endpoint serves."""
+
+    def __init__(self, members, error=None):
+        self.members = members
+        self.error = error
+        self.calls = 0
+
+    def get_members(self, workspace_slug, project_id):
+        """Return the configured members, or raise to simulate the lookup being unavailable."""
+        self.calls += 1
+        if self.error:
+            raise self.error
+        return [ProjectMember.model_validate(m) for m in self.members]
+
+
+class MemberAwareClient(FakeClient):
+    """A FakeClient that can also answer the project-member lookup the guard makes."""
+
+    def __init__(self, members, error=None):
+        super().__init__()
+        self.projects = FakeProjects(members, error)
+
+
+def _assign(monkeypatch, client, assignees, tool="update_work_item"):
+    """Call a write tool with the given assignees, defaulting to the destructive update path."""
+    args = {"project_id": "p", "work_item_id": "w", "assignees": assignees}
+    if tool == "create_work_item":
+        args = {"project_id": "p", "name": "X", "assignees": assignees}
+    return _call(monkeypatch, client, tool, args)
+
+
+@pytest.mark.parametrize(
+    "members,bad_id,reason",
+    [
+        ([MEMBER], "stranger-1", "stranger-1 (not a member of this project)"),
+        ([MEMBER, GUEST], "guest-1", "project role 5 is below member"),
+        ([MEMBER, INACTIVE], "inactive-1", "project membership is inactive"),
+    ],
+    ids=["not-a-member", "below-member-role", "inactive-membership"],
+)
+def test_unassignable_assignee_is_rejected_before_the_write(monkeypatch, members, bad_id, reason):
+    """Each way Plane filters an id out must raise, name why, and leave the write unsent.
+
+    The error also has to name an id that would work — a caller cannot guess one.
+    """
+    client = MemberAwareClient(members)
+    with pytest.raises(ToolError) as exc:
+        _assign(monkeypatch, client, [bad_id])
+    assert reason in str(exc.value)
+    assert "member@example.com=member-1" in str(exc.value)
+    assert client.work_items.updated is None, "the destructive update must not be issued"
+
+
+def test_assignable_member_passes_through(monkeypatch):
+    """The happy path is unchanged: a real member is written as before."""
+    client = MemberAwareClient([MEMBER])
+    _assign(monkeypatch, client, ["member-1"])
+    assert client.work_items.updated.assignees == ["member-1"]
+
+
+def test_members_without_role_are_accepted_on_membership_alone(monkeypatch):
+    """Some deployments omit role/is_active; an unreported role must not fail everyone."""
+    client = MemberAwareClient([BARE])
+    _assign(monkeypatch, client, ["bare-1"])
+    assert client.work_items.updated.assignees == ["bare-1"]
+
+
+def test_member_lookup_failure_does_not_block_the_write(monkeypatch):
+    """A pre-check must not become a new failure mode when the lookup itself breaks."""
+    client = MemberAwareClient([], error=RuntimeError("members endpoint unavailable"))
+    _assign(monkeypatch, client, ["member-1"])
+    assert client.work_items.updated.assignees == ["member-1"]
+
+
+def test_empty_assignees_skips_the_member_lookup(monkeypatch):
+    """Writes that carry no assignees must not pay for an extra request."""
+    client = MemberAwareClient([MEMBER])
+    _call(monkeypatch, client, "update_work_item", {"project_id": "p", "work_item_id": "w", "name": "Y"})
+    assert client.projects.calls == 0
+
+
+def test_create_work_item_rejects_unassignable_assignee(monkeypatch):
+    """Create cannot wipe anything, but the requested assignment still silently fails."""
+    client = MemberAwareClient([MEMBER])
+    with pytest.raises(ToolError) as exc:
+        _assign(monkeypatch, client, ["stranger-1"], tool="create_work_item")
+    assert "not a member of this project" in str(exc.value)
+    assert client.work_items.created is None
+
+
+def test_manage_assignee_rejects_unassignable_add(monkeypatch):
+    """The read-modify-write in manage_work_item_assignee is what makes this destructive."""
+    client = MemberAwareClient([MEMBER])
+    with pytest.raises(ToolError):
+        _call(
+            monkeypatch,
+            client,
+            "manage_work_item_assignee",
+            {"project_id": "p", "work_item_id": "w", "add_user_id": "stranger-1"},
+        )
+    assert client.work_items.updated is None, "existing-user must survive a rejected add"
+
+
+def test_manage_assignee_removal_is_not_blocked_by_a_stale_assignee(monkeypatch):
+    """Only the incoming id is checked, so losing access does not trap the existing list."""
+    client = MemberAwareClient([MEMBER])  # "existing-user" is no longer a member
+    _call(
+        monkeypatch,
+        client,
+        "manage_work_item_assignee",
+        {"project_id": "p", "work_item_id": "w", "remove_user_id": "existing-user"},
+    )
+    assert client.work_items.updated.assignees == []
+    assert client.projects.calls == 0, "a pure removal introduces no id to check"


### PR DESCRIPTION
Fixes #193.

## What's going on

Plane filters assignee ids it won't accept out of the payload during validation instead of rejecting them, and an update deletes the work item's existing assignees before writing that filtered list. So one unassignable id clears the assignees and still answers `200` — the caller sees a write that both failed and destroyed data.

There are three ways to land there and none of them show up in the response: the user is a workspace member but not a member of *this* project, their project role is guest (below the `role >= 15` floor), or the project membership is inactive.

`manage_work_item_assignee` is the worst of the three call sites, because it reads the current assignees, appends one id, and writes the whole list back — so a single bad id discards the list it just read, which is exactly what that tool exists to prevent.

## What this changes

`_assert_assignable()` in `plane_mcp/tools/work_items.py` looks up the project's members and raises before the write if any requested id isn't assignable. The message names both what was rejected and what would work, so a caller can recover without guessing:

```
Plane silently drops assignees it will not accept, and an update clears the work item's
existing assignees in the process. Rejected: 3f2b9c14-… (not a member of this project).
Only active project members at member role or above can be assigned. Assignable members
of this project: alice@example.com=7d4e1a05-…, bob@example.com=c81f6b32-…
Add the user to the project first, or use one of the IDs above.
```

It's wired into `create_work_item`, `update_work_item` and `manage_work_item_assignee`. The last one checks only the incoming `add_user_id` rather than the merged list — validating the merged list would let an already-assigned member who has since lost project access block a legitimate *removal*, and such a member gets dropped by Plane on any write anyway, so that isn't a loss this change introduces.

A few things I was deliberate about:

- **It can't introduce a new failure mode.** If the member lookup itself fails or answers in a shape we don't expect, it's logged and the write proceeds exactly as it does today.
- **It doesn't add 404 surface.** The check calls `projects.get_members()` (non-lite), which self-managed instances serve, so it works even on deployments where the `get_project_members` *tool* still 404s per #172/#188. This doesn't touch the same lines as #173 and doesn't depend on it.
- **It tolerates partial member payloads.** Community Edition's `project-members` returns a bare user record with no `role` or `is_active`, so an unreported role falls back to a membership-only check rather than disqualifying everyone. Membership alone still catches the common case.
- **It costs nothing on the happy path.** Writes that carry no assignees issue no extra request.

Scope is one source file plus tests. No return types, tool signatures or existing behaviour change.

## Testing

Added 8 tests to `tests/test_work_items.py` (10 cases): the three rejection reasons parametrized, a valid member passing through, `role`/`is_active` absent, the member lookup failing, no assignees meaning no extra request, the `create_work_item` and `manage_work_item_assignee` call sites, and a removal not being blocked by a stale assignee. I checked these against the pre-fix tree to make sure they weren't vacuous — 5 of the cases fail without the change.

`ruff check` and `ruff format --check` are clean on both files and the repo-wide lint count is unchanged. Full non-integration suite: 66 passed (56 before, 10 new cases).

For an end-to-end check I built the wheel, installed it into a clean venv with no editable link to the source tree, and ran `plane-mcp-server stdio` as a real subprocess with a client talking JSON-RPC over its pipes. Against self-managed Plane 1.2.0: create with a non-member refused, `update_work_item` with a non-member refused **and the original assignee still intact**, `manage_work_item_assignee` with a bad id refused with the list preserved, a real member applied correctly, removals unaffected, non-assignee writes unaffected.

I repeated the core scenario over the HTTP header-auth transport (`/http/api-key/mcp`) as well, since that path builds the Plane client from the request's API key rather than from the environment.

I've since built the Docker image from the repo Dockerfile and run the server inside the container as well, in both `stdio` and the default `http` mode — same scenario, same results. (An earlier version of this description said the Docker path was unverified; it no longer is.)

## One open question

I could only verify against self-managed 1.2.0, so I'm not claiming Plane Cloud is affected. What I can say is that it isn't specific to that version: both halves are still on `makeplane/plane` `preview` at `3985693` — the [filter that drops unassignable ids](https://github.com/makeplane/plane/blob/39856932cd6b9bd17eab0920506d628190b47af2/apps/api/plane/api/serializers/issue.py#L106-L113) and the [unconditional delete before the write](https://github.com/makeplane/plane/blob/39856932cd6b9bd17eab0920506d628190b47af2/apps/api/plane/api/serializers/issue.py#L244-L245).

If someone with a Cloud workspace can check, it takes about a minute: assign a work item to a user who's in the workspace but not in that project, then re-read it and see whether the previous assignee survived. If Cloud behaves the same, this stops being a self-hosting fix and becomes a general one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented inactive users and users without sufficient project membership from being assigned to work items.
  * Added validation before creating or updating assignments to prevent unintended assignee removal.
  * Preserved existing assignees when an invalid new assignee is rejected.
  * Allowed removal of assignees who are no longer active or present in the project.
  * Continued processing when member verification is unavailable or incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
