### PR TITLE
fix: refuse an assignee Plane will not accept, rather than lose the field

### DIFF
--- a/plane_mcp/tools/workitem.py
+++ b/plane_mcp/tools/workitem.py
@@ -51,6 +51,9 @@ TITLE = "Work items"
 
 PRIORITIES = get_args(PriorityEnum)
 
+# Plane's floor for an assignable project member; guest sits below it.
+_MEMBER_ROLE = 15
+
 WRITE_FIELDS = (
     "name",
     "assignees",
@@ -175,6 +178,37 @@ def _scoped_pql(pql: str, project_id: str) -> str:
         return pql
     scope = f'project = "{project_id}"'
     return f"({pql}) AND {scope}" if pql else scope
+
+
+def _unassignable(client: Any, workspace_slug: str, project_id: str, wanted: list[str]) -> str | None:
+    """Name the assignee ids Plane would drop, because dropping them is invisible.
+
+    Validation filters an assignee it will not accept out of the payload, and an
+    update deletes the work item's existing assignees before writing what is left.
+    So one unassignable id both fails to apply and clears the field, under a 200.
+    """
+    try:
+        members = client.projects.get_members(workspace_slug=workspace_slug, project_id=project_id)
+    except HttpError as exc:
+        logger.warning("could not read members of project %s (%s); skipping the assignee check", project_id, exc)
+        return None
+    # Community Edition omits role and is_active, so an absent one cannot disqualify.
+    assignable = {
+        member.id
+        for member in members
+        if member.id and member.is_active is not False and (member.role is None or member.role >= _MEMBER_ROLE)
+    }
+    if not assignable:  # nothing readable to judge against; never block a write that works today
+        return None
+    rejected = [user_id for user_id in wanted if user_id not in assignable]
+    if not rejected:
+        return None
+    return (
+        f"Error: not assignable in this project: {', '.join(rejected)}. Plane drops an assignee it "
+        "will not accept without reporting it, and clears the work item's existing assignees in the "
+        "process. Only active project members at member role or above can be assigned -- "
+        "`member list_project` lists them."
+    )
 
 
 def _description_html(description_html: str, description_stripped: str) -> str | None:
@@ -352,6 +386,10 @@ def register(mcp: FastMCP) -> None:
         if not project_id:
             return missing(action, "project_id")
 
+        if action in ("create", "update") and (wanted := coerce_list(assignees)):
+            if error := _unassignable(client, workspace_slug, project_id, wanted):
+                return error
+
         if action == "create":
             if not name:
                 return missing(action, "name")
@@ -399,6 +437,9 @@ def register(mcp: FastMCP) -> None:
             return missing(action, f"add_{field[:-1]}_id or remove_{field[:-1]}_id")
         # Either side takes one id or several, so adding three assignees is one call.
         adding, removing = coerce_list(add) or [], coerce_list(remove) or []
+        if field == "assignees" and adding:
+            if error := _unassignable(client, workspace_slug, project_id, adding):
+                return error
         current = client.work_items.retrieve(
             workspace_slug=workspace_slug, project_id=project_id, work_item_id=workitem_id
         )

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -8,6 +8,7 @@ validation is the thing under test rather than an assumption.
 from __future__ import annotations
 
 import pytest
+from plane.models.projects import ProjectMember
 
 from plane_mcp.coercion import accepted_types, coerce_arguments
 
@@ -152,10 +153,15 @@ WORK_ITEM_MODULE = "plane_mcp.tools.workitem"
 
 
 class _Recorder:
-    """Stands in for the Plane client; records the first SDK call and stops."""
+    """Stands in for the Plane client; records the first SDK call and stops.
+
+    A write carrying assignees reads the project's members first, so that lookup
+    has to answer -- and answer with the assignee -- rather than be the recorded call.
+    """
 
     def __init__(self):
         self.kwargs: dict = {}
+        self.get_members = lambda **_: [ProjectMember(id=ASSIGNEE)]
 
     def __getattr__(self, _name):
         return self

--- a/tests/tools/test_dispatch.py
+++ b/tests/tools/test_dispatch.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 import inspect
 
 import pytest
+from plane.errors.errors import HttpError
+from plane.models.projects import ProjectMember
 
 from plane_mcp.toolkit.spec import action_names
+from plane_mcp.tools.workitem import _MEMBER_ROLE
 
 # Values that satisfy a parameter well enough to reach the SDK call. Enum-valued
 # parameters need a member of their own vocabulary; the rest take a plausible id.
@@ -226,6 +229,99 @@ def test_a_valid_priority_still_reaches_the_sdk(registered, spy):
     registered["workitem"].fn(action="create", project_id="p", name="x", priority="urgent")
 
     assert spy.recorder.only().kwargs["data"].priority == "urgent"
+
+
+# The same defect one layer out: Plane filters an assignee it will not accept out of
+# the payload, and the update deletes the existing assignees before writing what is
+# left. So naming one both fails to assign and clears the field, under a 200.
+
+ALICE = ("alice", 20, True)
+
+
+def _project_members(*rows):
+    return [
+        ProjectMember(id=id_, email=f"{id_}@example.com", role=role, is_active=active) for id_, role, active in rows
+    ]
+
+
+@pytest.mark.parametrize(
+    ("members", "why"),
+    [
+        ([ALICE], "not a member of this project"),
+        ([ALICE, ("bob", 5, True)], "a guest, below the assignable role"),
+        ([ALICE, ("bob", 20, False)], "an inactive membership"),
+    ],
+    ids=["non-member", "guest", "inactive"],
+)
+def test_an_unassignable_assignee_is_refused_before_the_write(members, why, registered, spy):
+    spy.returns["projects.get_members"] = _project_members(*members)
+
+    result = registered["workitem"].fn(action="update", project_id="p", workitem_id="w", assignees=["bob"])
+
+    assert isinstance(result, str) and result.startswith("Error:"), f"{why}: {result}"
+    assert "bob" in result, f"{why}: refused without naming who was rejected"
+    assert "work_items.update" not in spy.recorder.methods, f"{why}: wrote anyway, clearing the assignees"
+
+
+@pytest.mark.parametrize("role", [20, _MEMBER_ROLE], ids=["above the floor", "exactly the floor"])
+def test_an_assignable_member_reaches_the_sdk(role, registered, spy):
+    spy.returns["projects.get_members"] = _project_members(("bob", role, True))
+
+    registered["workitem"].fn(action="create", project_id="p", name="x", assignees=["bob"])
+
+    create = next(c for c in spy.recorder.calls if c.method == "work_items.create")
+    assert create.kwargs["data"].assignees == ["bob"]
+
+
+def test_membership_alone_decides_when_the_edition_omits_role(registered, spy):
+    """Community Edition answers with identity fields only; an absent role cannot disqualify."""
+    spy.returns["projects.get_members"] = [ProjectMember(id="bob")]
+
+    registered["workitem"].fn(action="create", project_id="p", name="x", assignees=["bob"])
+
+    assert "work_items.create" in spy.recorder.methods
+
+
+@pytest.mark.parametrize(
+    "members",
+    [HttpError("nope", 404), []],
+    ids=["lookup fails", "nothing to judge against"],
+)
+def test_an_unusable_member_list_does_not_block_the_write(members, registered, spy):
+    """The check guards a write that works today; it must not become a new way to fail."""
+    spy.returns["projects.get_members"] = members
+
+    registered["workitem"].fn(action="create", project_id="p", name="x", assignees=["bob"])
+
+    assert "work_items.create" in spy.recorder.methods
+
+
+def test_a_write_carrying_no_assignees_costs_no_extra_request(registered, spy):
+    registered["workitem"].fn(action="update", project_id="p", workitem_id="w", name="renamed")
+
+    assert spy.recorder.methods == ["work_items.update"]
+
+
+def test_adding_an_unassignable_assignee_is_refused(registered, spy):
+    spy.returns["projects.get_members"] = _project_members(ALICE)
+
+    result = registered["workitem"].fn(action="manage_assignee", project_id="p", workitem_id="w", add_user_id="bob")
+
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "work_items.update" not in spy.recorder.methods
+
+
+def test_removing_an_assignee_is_never_blocked(registered, spy):
+    """Whoever is on the item may no longer be assignable; that must not trap them there."""
+    from types import SimpleNamespace
+
+    spy.returns["projects.get_members"] = _project_members(ALICE)
+    spy.returns["work_items.retrieve"] = SimpleNamespace(assignees=["bob"], labels=[])
+
+    registered["workitem"].fn(action="manage_assignee", project_id="p", workitem_id="w", remove_user_id="bob")
+
+    update = next(c for c in spy.recorder.calls if c.method == "work_items.update")
+    assert update.kwargs["data"].assignees == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Plane filters an assignee id it will not accept out of the payload during validation, and an update deletes the work item's existing assignees before writing what is left. A write naming one therefore both fails to apply *and* clears the field, under a `200` — nothing in the response distinguishes it from a successful assignment.

Measured against self-managed 1.2.0, through v0.3.0's own `workitem` tool, where `alice` is a member of the project and `bob` is a workspace member who isn't:

| request | result | reported |
|---|---|---|
| `update assignees=[bob]` | `[]` — alice gone, bob never added | success |
| `update assignees=[alice, bob]` | `[alice]` — bob silently missing | success |
| `manage_assignee add_user_id=bob` | unchanged | success |

Only the first destroys data, and it is the one that bites in practice: an agent told "assign these twelve to bob", where bob isn't in that project, clears the assignee on twelve items and reports twelve successes.

Three ways to land there, none of them visible to the caller: the user is a workspace member but not a member of *this* project; their project role is guest, below Plane's `role__gte=15` floor; or the membership is `is_active=False`. Both halves are on `makeplane/plane` `preview` — the [filter that drops the id](https://github.com/makeplane/plane/blob/39856932cd6b9bd17eab0920506d628190b47af2/apps/api/plane/api/serializers/issue.py#L106-L113) and the [unconditional delete before the write](https://github.com/makeplane/plane/blob/39856932cd6b9bd17eab0920506d628190b47af2/apps/api/plane/api/serializers/issue.py#L244-L245).

It is the same failure `tools/README.md` already rules out for enum parameters — *"dropping it writes the record without the field and reports success"* — one layer out, where the value is a UUID and the API does the dropping.

### What changed

`_unassignable()` reads the project's members and names the rejected ids before the write. Wired into `create`, `update` and `manage_assignee`:

```
Error: not assignable in this project: 3d0f6b63-…. Plane drops an assignee it will not
accept without reporting it, and clears the work item's existing assignees in the process.
Only active project members at member role or above can be assigned -- `member list_project`
lists them.
```

Notes:

- **It cannot become a new way to fail.** An unreadable member list (`HttpError`) or an empty one skips the check, and the write proceeds exactly as it does today.
- **Community Edition carries no `role`.** `/project-members` answers with identity fields only there, so an absent `role` or `is_active` cannot disqualify anyone — membership alone decides. Where both are present, guest and inactive are caught too.
- **It doesn't touch the 404 surface.** `projects.get_members()` is the non-lite endpoint, which self-managed serves; `project-members-lite` 404s there, per #172 / #188.
- **It costs nothing unless assignees are in play.** A write without them issues no extra request; one carrying them costs a single GET.

`manage_assignee` validates only the incoming id rather than the merged list, so a member who has since lost project access can still be *removed*.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### Test Scenarios

**Unit** — 7 tests, 11 cases in `tests/tools/test_dispatch.py`, beside the enum-dropping test they are a variation of:

- the three rejection reasons: non-member, guest, inactive membership
- a role above the floor, and one exactly on it
- the Community Edition shape, with `role` absent
- a failing member lookup, and an empty one, each letting the write through
- a write with no assignees making no extra request
- `manage_assignee` refusing an add, and a removal not being blocked

Checked against the pre-fix tree: 4 of the 11 fail without the guard, and the other 7 are the "must keep working" half that should pass either way.

`1092 passed, 25 skipped`. `ruff check` and `ruff format --check` clean. One existing test needed a line — `test_coercion.py`'s recorder stops at the first SDK call, and the preflight is now that call, so it answers the member lookup rather than being consumed by it.

**End to end** — built the wheel, installed it into a clean venv with no editable link to the source tree, and ran `plane-mcp-server stdio` as a real subprocess driven over JSON-RPC against self-managed 1.2.0. 14/14:

- create with a real member unaffected; update with a non-member refused **and the original assignee still there**; `manage_assignee` add refused with the list intact; adding a real member still works; removal not blocked; a write carrying no assignees unaffected; `manage_label` not caught by the assignee check.
- **Retired names**: `update_work_item` and `manage_work_item_assignee` are guarded the same way; `create_work_item` and `retrieve_work_item` are unaffected.

I verified the non-member case live. Guest and inactive membership go through the same filter, so I would expect them to behave identically, but testing those means reshuffling memberships on a live workspace — they are covered by unit tests only.

### References

Fixes #193. Replaces #194, which patched `plane_mcp/tools/work_items.py` — a file this refactor removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assignee changes now verify that users are active project members with sufficient permissions before updates are saved.
  * Prevented invalid assignments from being silently dropped or existing assignments from being unintentionally cleared.
  * Assignee removals continue to work regardless of current member status.
  * Updates proceed when membership information is unavailable or inconclusive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
