### PR TITLE
fix: update logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Structured JSON. Each tool call logs its name, duration, status and — when
 available — an opaque user id and the workspace slug.
 
 ```bash
-export LOG_USER_INFO=true    # also log the display name (PII);
+export LOG_USER_INFO=false    # also log the display name (PII);
 export LOG_PAYLOADS=false    # keep request payloads out of logs; default true
 ```
 

--- a/plane_mcp/tools/README.md
+++ b/plane_mcp/tools/README.md
@@ -68,7 +68,7 @@ Both implement `list_tools`/`get_tool` only, so execution keeps the full schema 
 
 | Transform | Effect |
 |---|---|
-| `StripOutputSchemas` | Drops `outputSchema` from the listing — roughly two thirds of the wire payload, for a field no client forwards to a model |
+| `StripOutputSchemas` | Drops `outputSchema` from the listing — roughly two-thirds of the wire payload, for a field no client forwards to a model |
 | `LegacyNames` | Resolves a retired tool name to its `(tool, action)` pair, with `action` hidden and pre-filled |
 
 ## Retired tool names

--- a/plane_mcp/tools/collection.py
+++ b/plane_mcp/tools/collection.py
@@ -165,6 +165,8 @@ def register(mcp: FastMCP) -> None:
             return collections.retrieve(workspace_slug=workspace_slug, collection_id=collection_id)
 
         if action == "update":
+            if not name and sort_order is None:
+                return missing(action, "name or sort_order")
             return collections.update(
                 workspace_slug=workspace_slug,
                 collection_id=collection_id,

--- a/tests/tools/test_dispatch.py
+++ b/tests/tools/test_dispatch.py
@@ -44,6 +44,7 @@ CONDITIONAL: dict[tuple[str, str], dict[str, object]] = {
     # Without project_id this is the workspace catalogue, which requires a group.
     ("state", "create"): {"group": "started"},
     ("template", "update"): {"name": "Renamed"},
+    ("collection", "update"): {"name": "Renamed"},
     ("cycle", "manage_workitems"): {"add_ids": "id-1"},
     ("module", "manage_workitems"): {"add_ids": "id-1"},
     ("milestone", "manage_workitems"): {"add_ids": "id-1"},


### PR DESCRIPTION
### Description

Updates the MCP logging documentation to reflect the default `LOG_USER_INFO=false` configuration, improves collection update validation by requiring at least one mutable field, and adds test coverage for collection update dispatch validation.

### Changes

* Update logging configuration documentation to reflect the default PII-safe setting.
* Validate collection updates to ensure `name` or `sort_order` is provided.
* Add collection update coverage to dispatch validation tests.
* Minor documentation formatting improvements.