### PR TITLE
fix(oauth): omit unsupported Plane scopes

### DIFF
--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -187,7 +187,9 @@ class PlaneOAuthTokenVerifier(TokenVerifier):
                 return AccessToken(
                     token=token,
                     client_id=user.id or "unknown",
-                    scopes=["read", "write"],  # Plane doesn't expose scopes in user endpoint
+                    # Plane does not expose granted scopes in the user endpoint.
+                    # The completed OAuth flow requested these required scopes.
+                    scopes=list(self.required_scopes or []),
                     expires_at=expires_at,
                     claims={
                         "auth_method": "oauth",

--- a/plane_mcp/auth/plane_oauth_provider.py
+++ b/plane_mcp/auth/plane_oauth_provider.py
@@ -363,7 +363,7 @@ class PlaneOAuthProvider(OAuthProxy):
             client_storage=client_storage,
             jwt_signing_key=settings.jwt_signing_key,
             require_authorization_consent=require_authorization_consent,
-            valid_scopes=["read", "write"],
+            valid_scopes=required_scopes_final,
             enable_cimd=settings.enable_cimd,
         )
 

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -72,7 +72,7 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
             plane_internal_base_url=os.getenv("PLANE_INTERNAL_BASE_URL", ""),
             enable_cimd=os.getenv("PLANE_OAUTH_PROVIDER_ENABLE_CIMD", "false").lower() == "true",
             client_storage=build_token_store(),
-            required_scopes=["read", "write"],
+            required_scopes=[],
             allowed_client_redirect_uris=get_allowed_client_redirect_uris(),
         ),
     )

--- a/tests/test_oauth_scopes.py
+++ b/tests/test_oauth_scopes.py
@@ -1,12 +1,15 @@
 """Regression tests for Plane OAuth scope forwarding."""
 
+import asyncio
 from urllib.parse import parse_qs, urlparse
 
+import httpx
 from fastmcp import FastMCP
 from key_value.aio.stores.memory import MemoryStore
 from starlette.testclient import TestClient
 
 from plane_mcp.auth import PlaneOAuthProvider
+from plane_mcp.auth.plane_oauth_provider import PlaneOAuthTokenVerifier
 
 
 def test_empty_required_scopes_are_advertised_and_omitted_upstream():
@@ -52,3 +55,43 @@ def test_empty_required_scopes_are_advertised_and_omitted_upstream():
     assert response.status_code == 302
     upstream_query = parse_qs(urlparse(response.headers["location"]).query, keep_blank_values=True)
     assert "scope" not in upstream_query
+
+
+def test_token_verifier_returns_configured_scopes(monkeypatch):
+    required_scopes = ["projects:read"]
+    verifier = PlaneOAuthTokenVerifier(
+        required_scopes=required_scopes,
+        plane_base_url="http://plane.example",
+    )
+    user = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "email": "user@example.com",
+        "first_name": "Test",
+        "last_name": "User",
+        "display_name": "Test User",
+        "avatar": "",
+        "avatar_url": None,
+    }
+    installation = {
+        "id": "installation-1",
+        "workspace_detail": {"name": "Test", "slug": "test", "id": "workspace-1"},
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/users/me/":
+            return httpx.Response(200, json=user)
+        if request.url.path == "/auth/o/app-installation/":
+            return httpx.Response(200, json=[installation])
+        return httpx.Response(404)
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_async_client(transport=httpx.MockTransport(handler), **kwargs),
+    )
+
+    access_token = asyncio.run(verifier.verify_token("upstream-token"))
+
+    assert access_token is not None
+    assert access_token.scopes == required_scopes

--- a/tests/test_oauth_scopes.py
+++ b/tests/test_oauth_scopes.py
@@ -1,0 +1,54 @@
+"""Regression tests for Plane OAuth scope forwarding."""
+
+from urllib.parse import parse_qs, urlparse
+
+from fastmcp import FastMCP
+from key_value.aio.stores.memory import MemoryStore
+from starlette.testclient import TestClient
+
+from plane_mcp.auth import PlaneOAuthProvider
+
+
+def test_empty_required_scopes_are_advertised_and_omitted_upstream():
+    provider = PlaneOAuthProvider(
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        base_url="http://localhost:8211",
+        plane_base_url="http://plane.example",
+        plane_internal_base_url="http://plane.example",
+        client_storage=MemoryStore(),
+        required_scopes=[],
+        allowed_client_redirect_uris=["http://localhost:*/*"],
+        require_authorization_consent=False,
+    )
+    app = FastMCP("Plane MCP Server", auth=provider).http_app()
+
+    with TestClient(app, follow_redirects=False) as client:
+        metadata = client.get("/.well-known/oauth-authorization-server").json()
+        assert metadata["scopes_supported"] == []
+
+        registration = client.post(
+            "/register",
+            json={
+                "redirect_uris": ["http://localhost:3000/callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "client_secret_post",
+            },
+        )
+        assert registration.status_code == 201
+
+        response = client.get(
+            "/authorize",
+            params={
+                "client_id": registration.json()["client_id"],
+                "redirect_uri": "http://localhost:3000/callback",
+                "response_type": "code",
+                "code_challenge": "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+                "code_challenge_method": "S256",
+            },
+        )
+
+    assert response.status_code == 302
+    upstream_query = parse_qs(urlparse(response.headers["location"]).query, keep_blank_values=True)
+    assert "scope" not in upstream_query


### PR DESCRIPTION
## Summary

- stop requesting Plane's unsupported bare `read` and `write` OAuth scopes
- advertise configured required scopes instead of a separate hardcoded list
- keep verified token scope claims aligned with configured required scopes
- add regression coverage for empty scope metadata, omitted upstream `scope`, and custom verifier scopes

Fixes #207.

## Why

Plane uses resource/action scopes such as `projects:read`. FastMCP forwarded the hardcoded values as `scope=read write`, causing Plane to return `invalid_scope` before token exchange.

With empty required scopes, FastMCP omits the upstream `scope` parameter and Plane can apply the OAuth app's configured permissions.

## Scope

Header-auth scope handling remains intentionally unchanged:

- `PlaneHeaderAuthProvider(required_scopes=["read", "write"])` does not run Plane's OAuth authorization flow or send scopes upstream. It validates a presented API key and returns matching internal `AccessToken.scopes` values, so it cannot trigger Plane's `invalid_scope` response.
`PlaneOAuthTokenVerifier` now returns its configured required scopes so custom resource/action scopes remain consistent through downstream authorization. Plane's user endpoint does not expose granted scopes, so these claims reflect scopes requested by the completed OAuth flow.

## Validation

- `pytest tests/test_oauth_scopes.py tests/test_oauth_security.py -q`: 10 passed
- Ruff lint and format checks passed
- Kubernetes OAuth E2E against a strict Plane-compatible mock:
  - unmodified v0.3.0: `scope=read write` → `invalid_scope`
  - patched image: DCR, PKCE, browser consent, token exchange, identity verification, MCP initialization, and `tools/list` succeeded
  - result: `SUCCESS server='Plane MCP Server' tools=28`
  - custom `projects:read` configuration: authorization requested `scope=projects%3Aread`; token verification, MCP initialization, and `tools/list` succeeded
- Live Plane v3.0.0 authorization endpoint verification:
  - `scope=read write` returned `invalid_scope`
  - valid resource/action scope passed initial authorization validation
  - absent `scope` passed initial authorization validation and was preserved through the login redirect

Full suite on supported Python 3.11: 1083 passed, 25 skipped.

---

*This code was generated using GPT-5.6 Sol in Pi Coding Agent.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth authentication now honors the configured scope settings instead of requiring fixed read/write scopes.
  * OAuth requests correctly omit the scope when no scopes are configured.
  * Token verification now reports the configured scopes accurately.

* **Tests**
  * Added regression coverage for scope-free OAuth registration, authorization, and upstream requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->