### PR TITLE
fix: describe what transfer_workitems actually does

### DIFF
--- a/plane_mcp/tools/cycle.py
+++ b/plane_mcp/tools/cycle.py
@@ -64,7 +64,14 @@ ACTIONS = (
         ("add_ids", "remove_ids"),
         note="pass at least one of add_ids or remove_ids; returns nothing, read back with list_workitems",
     ),
-    Action("transfer_workitems", ("project_id", "cycle_id", "new_cycle_id"), note="moves everything to new_cycle_id"),
+    Action(
+        "transfer_workitems",
+        ("project_id", "cycle_id", "new_cycle_id"),
+        note=(
+            "moves only the unfinished work items to new_cycle_id; the source cycle must have "
+            "ended first, so complete it before transferring or the call is rejected"
+        ),
+    ),
     Action("complete", ("project_id", "cycle_id"), note="sets end_date to today"),
     Action("archive", ("project_id", "cycle_id"), note="ends the cycle first if it is still running"),
     Action("unarchive", ("project_id", "cycle_id")),


### PR DESCRIPTION
## Description

`cycle.transfer_workitems` advertised itself as *"moves everything to new_cycle_id"*. Both halves of that are wrong.

1. **It moves only unfinished work items.** The endpoint's own API description: *"Move incomplete work items from the current cycle to a new target cycle. Captures progress snapshot and transfers only unfinished work items."*
2. **It refuses unless the source cycle has already ended**, and nothing on the surface said so:

```python
# plane/api/views/cycle.py — TransferCycleIssueAPIEndpoint.post
if old_cycle.end_date is not None and old_cycle.end_date > timezone.now():
    return Response({"error": "The old cycle is not completed yet"}, status=400)
```

So for the ordinary request *"this sprint is wrapping up — close it and move the leftover work to the next one"*, the intuitive order is rejected. You must complete the cycle first, **then** transfer. An agent discovers this only by making the call and reading a bare 400.

## How it was found

While measuring this tool surface with an eval harness. Three models across two vendor CLIs hit it on the same task, deterministically — identical arguments, identical 400, then a recovery attempt. It was the most-errored action in every run, and the only error attributable to the tool description rather than to the model.

| run | errored / calls |
|---|---|
| gpt-5.6-luna (codex-cli) | 2 / 4 |
| sonnet (claude-cli) | 2 / 4 |
| haiku (claude-cli) | 2 / 5 |

Every one of those is a wasted round trip paid by every agent that tries the obvious order.

## Verified by re-measuring

Same task, same models, same harness — only the note changed:

| | pass | total calls | `transfer_workitems` errored |
|---|---|---|---|
| sonnet, old note | 3/3 | 25 | **2 / 4** |
| haiku, old note | 3/3 | 23 | **2 / 5** |
| sonnet, new note | 3/3 | **18** | **0 / 3** |
| haiku, new note | 3/3 | **13** | **0 / 3** |

Every failed call is gone on both tiers, and the transfer count settles at exactly one per
repetition with no retries. Total calls fell 28% for sonnet and 43% for haiku, with success
unchanged. Haiku's incidental `cycle.list` and `project.retrieve` errors disappeared too —
it no longer has to re-orient after being refused.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Test Scenarios

- Ask an agent to close a running cycle and move its unfinished items to another cycle; it should now complete first and transfer second, without the failed call.
- Confirm the generated tool description carries the precondition: `transfer_workitems (project_id, cycle_id, new_cycle_id) -- moves only the unfinished work items to new_cycle_id; the source cycle must have ended first, so complete it before transferring or the call is rejected`

Note: `pytest tests/tools` reports 17 pre-existing failures on `origin/main` (all in `test_workitem_property.py`, `TypeError: 'function' object is not subscriptable`). Identical count with and without this change — unrelated, but worth someone's attention.

## References

Text-only change to one `Action` note; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that work item transfers include only unfinished items.
  * Documented that the source cycle must have ended before transfers can proceed.
  * Transfers are rejected when these conditions are not met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
