### PR TITLE
fix: populate project overview description

### DIFF
--- a/plane_mcp/toolkit/__init__.py
+++ b/plane_mcp/toolkit/__init__.py
@@ -44,6 +44,7 @@ from plane_mcp.toolkit.runtime import (
     opt,
     page_params,
     require,
+    rich_text,
 )
 from plane_mcp.toolkit.spec import (
     Action,
@@ -70,6 +71,7 @@ __all__ = [
     "needs",
     "one_of",
     "opt",
+    "rich_text",
     "page_params",
     "plan_gated",
     "plan_required",

--- a/plane_mcp/toolkit/runtime.py
+++ b/plane_mcp/toolkit/runtime.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from html import escape
 from typing import Any
 
 
@@ -61,6 +62,15 @@ def one_of(name: str, value: Any, allowed: Sequence[str], hint: str = "") -> str
 def opt(value: Any) -> Any:
     """Normalise a sentinel default ("" / 0) back to None for SDK payloads."""
     return value if value not in ("", 0) else None
+
+
+def rich_text(html: str, plain: str) -> str | None:
+    """The HTML for a rich-text field, promoting plain text when no HTML was given."""
+    if html:
+        return html
+    if plain:
+        return "<p>" + escape(plain).replace("\n", "<br/>") + "</p>"
+    return None
 
 
 def coerce_list(value: Any, *, split: bool = True) -> list[Any] | None:

--- a/plane_mcp/tools/project.py
+++ b/plane_mcp/tools/project.py
@@ -18,7 +18,7 @@ from plane.models.projects import (
 from plane.models.query_params import ProjectLiteListQueryParams
 
 from plane_mcp.client import get_plane_client_context
-from plane_mcp.toolkit import Action, build_annotations, build_description, missing, needs, opt, plan_gated
+from plane_mcp.toolkit import Action, build_annotations, build_description, missing, needs, opt, plan_gated, rich_text
 
 NAME = "project"
 TITLE = "Projects"
@@ -37,6 +37,7 @@ ACTIONS = (
         ("name", "identifier"),
         (
             "description",
+            "description_html",
             "project_lead",
             "default_assignee",
             "emoji",
@@ -54,6 +55,7 @@ ACTIONS = (
         (
             "name",
             "description",
+            "description_html",
             "identifier",
             "project_lead",
             "default_assignee",
@@ -140,6 +142,7 @@ def register(mcp: FastMCP) -> None:
         name: str = "",
         identifier: str = "",
         description: str = "",
+        description_html: str = "",
         project_lead: str = "",
         default_assignee: str = "",
         emoji: str = "",
@@ -205,6 +208,7 @@ def register(mcp: FastMCP) -> None:
                     name=name,
                     identifier=identifier,
                     description=opt(description),
+                    description_html=rich_text(description_html, description),
                     project_lead=opt(project_lead),
                     default_assignee=opt(default_assignee),
                     emoji=opt(emoji),
@@ -236,6 +240,7 @@ def register(mcp: FastMCP) -> None:
                 data=UpdateProject(
                     name=opt(name),
                     description=opt(description),
+                    description_html=rich_text(description_html, description),
                     identifier=opt(identifier),
                     project_lead=opt(project_lead),
                     default_assignee=opt(default_assignee),

--- a/plane_mcp/tools/workitem.py
+++ b/plane_mcp/tools/workitem.py
@@ -7,7 +7,6 @@ merging them teaches the model to filter on a field the API rejects.
 
 from __future__ import annotations
 
-from html import escape
 from typing import Annotated, Any, Literal, get_args
 
 from fastmcp import FastMCP
@@ -42,6 +41,7 @@ from plane_mcp.toolkit import (
     one_of,
     opt,
     pql_failure,
+    rich_text,
 )
 
 logger = get_logger(__name__)
@@ -177,15 +177,6 @@ def _scoped_pql(pql: str, project_id: str) -> str:
     return f"({pql}) AND {scope}" if pql else scope
 
 
-def _description_html(description_html: str, description_stripped: str) -> str | None:
-    """Plane recomputes the stripped form server-side, so plain text must be wrapped."""
-    if description_html:
-        return description_html
-    if description_stripped:
-        return "<p>" + escape(description_stripped).replace("\n", "<br/>") + "</p>"
-    return None
-
-
 def register(mcp: FastMCP) -> None:
     @mcp.tool(
         name=NAME,
@@ -268,7 +259,7 @@ def register(mcp: FastMCP) -> None:
                 "labels": coerce_list(labels),
                 "type_id": opt(type_id),
                 "point": opt(point),
-                "description_html": _description_html(description_html, description_stripped),
+                "description_html": rich_text(description_html, description_stripped),
                 "priority": opt(priority),
                 "start_date": opt(start_date),
                 "target_date": opt(target_date),


### PR DESCRIPTION
# Description

## Summary

Fix project descriptions not appearing in the project overview when created or updated through the external API.

## Changes

* Add rich-text handling for project descriptions.
* Populate `description_html` from the provided description when HTML is not supplied.
* Reuse the shared rich-text helper for work item descriptions.
* Expose `description_html` in project tool inputs and outputs.

## Impact

Project descriptions created or updated through MCP/external APIs now render correctly in the project overview.
