### PR TITLE
fix: answer a call that names no action with the actions it could name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,9 @@ Ordered as registered; the earlier one wraps the later:
 |---|---|
 | `PlaneLoggingMiddleware` | structured logging, plus the tool name |
 | `CoerceArguments` | repairs arguments a client encoded as strings, before validation (`coercion.py`) |
-| `ValidateActionArguments` | refuses arguments the chosen action does not accept, from the `ACTIONS` declaration |
+| `ValidateActionArguments` | refuses a call with no `action`, and arguments the chosen action does not accept, from the `ACTIONS` declaration |
 
-Coercion runs before validation so an argument is judged by the value it repairs to. `ValidateActionArguments` closes a gap a per-tool schema cannot: every action's parameters share one schema, so an argument meant for another action validated cleanly and was then dropped, and the call answered a different question than the one asked. Only arguments carrying a value are judged, and retired names are exempt — they arrive with no `action` and under their own parameter spelling.
+Coercion runs before validation so an argument is judged by the value it repairs to. `ValidateActionArguments` closes a gap a per-tool schema cannot: every action's parameters share one schema, so an argument meant for another action validated cleanly and was then dropped, and the call answered a different question than the one asked. Only arguments carrying a value are judged. It also answers a call that names no `action` at all, because the schema error for that case reports the missing parameter without reporting one permitted value — and an agent probing a tool with empty arguments to learn its interface is asking exactly the question the action list answers. Retired names are exempt from both checks: they are keyed by their own retired name, which the `ACTIONS` table does not carry, so nothing there claims them.
 
 ### Client Context (`client.py`)
 

--- a/plane_mcp/middleware.py
+++ b/plane_mcp/middleware.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Collection
 
-from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
+from fastmcp.tools.tool import ToolResult
 from fastmcp.utilities.logging import get_logger
 
 from plane_mcp.coercion import coerce_arguments
@@ -39,13 +39,7 @@ class ValidateActionArguments(Middleware):
         arguments = getattr(context.message, "arguments", None)
         if isinstance(arguments, dict) and (message := self.rejection(context.message.name, arguments)):
             logger.warning("Plane MCP: %s", message)
-            # An error, not a result that happens to read like one. This used to return a
-            # plain ToolResult, so a refused call arrived with isError false: the text said
-            # "Error" while the protocol said success. A caller measuring failures saw none,
-            # and a low-tier model repeated the same refused call more freely than when the
-            # schema rejected it. ToolError keeps the message -- it is the one exception
-            # FastMCP passes through rather than masking.
-            raise ToolError(message)
+            return ToolResult(content=message)
         return await call_next(context)
 
     def rejection(self, tool: str, arguments: dict) -> str | None:

--- a/plane_mcp/middleware.py
+++ b/plane_mcp/middleware.py
@@ -15,6 +15,11 @@ from plane_mcp.tools.registry import action_arguments
 logger = get_logger(__name__)
 
 
+def missing_action_error(tool: str, actions: Collection[str]) -> str:
+    """Error naming the actions `tool` offers, for a call that chose none."""
+    return f"Error: {tool} requires an action. It takes: {', '.join(sorted(actions))}."
+
+
 def stray_argument_error(action: str, arguments: dict, accepted: Collection[str]) -> str | None:
     """Error naming the arguments `action` does not take, or None when all are valid."""
     stray = sorted(n for n, value in arguments.items() if n != "action" and value and n not in accepted)
@@ -25,7 +30,7 @@ def stray_argument_error(action: str, arguments: dict, accepted: Collection[str]
 
 
 class ValidateActionArguments(Middleware):
-    """Refuse arguments the chosen action has no use for, before they are dropped."""
+    """Refuse a call whose action is absent, or whose arguments that action has no use for."""
 
     def __init__(self) -> None:
         self._accepted = action_arguments()
@@ -40,8 +45,17 @@ class ValidateActionArguments(Middleware):
     def rejection(self, tool: str, arguments: dict) -> str | None:
         """The message refusing this call, or None to let it through."""
         by_action = self._accepted.get(tool)
-        action = arguments.get("action")
-        if by_action is None or action not in by_action:
+        if by_action is None:
+            # A retired name, or not ours at all. Either way not our business.
+            return None
+        if "action" not in arguments:
+            # Pydantic names the parameter but not one permitted value, so a caller
+            # that omitted the choice learns nothing it did not already know.
+            return missing_action_error(tool, by_action)
+        action = arguments["action"]
+        if action not in by_action:
+            # A present-but-wrong action is left alone: the Literal already reports
+            # the permitted set, and a second opinion here would only muddle it.
             return None
         return stray_argument_error(action, arguments, by_action[action])
 

--- a/plane_mcp/middleware.py
+++ b/plane_mcp/middleware.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Collection
 
+from fastmcp.exceptions import ToolError
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from fastmcp.server.middleware.logging import StructuredLoggingMiddleware
-from fastmcp.tools.tool import ToolResult
 from fastmcp.utilities.logging import get_logger
 
 from plane_mcp.coercion import coerce_arguments
@@ -39,7 +39,13 @@ class ValidateActionArguments(Middleware):
         arguments = getattr(context.message, "arguments", None)
         if isinstance(arguments, dict) and (message := self.rejection(context.message.name, arguments)):
             logger.warning("Plane MCP: %s", message)
-            return ToolResult(content=message)
+            # An error, not a result that happens to read like one. This used to return a
+            # plain ToolResult, so a refused call arrived with isError false: the text said
+            # "Error" while the protocol said success. A caller measuring failures saw none,
+            # and a low-tier model repeated the same refused call more freely than when the
+            # schema rejected it. ToolError keeps the message -- it is the one exception
+            # FastMCP passes through rather than masking.
+            raise ToolError(message)
         return await call_next(context)
 
     def rejection(self, tool: str, arguments: dict) -> str | None:

--- a/plane_mcp/tools/project_estimate.py
+++ b/plane_mcp/tools/project_estimate.py
@@ -31,7 +31,12 @@ TYPES = ("categories", "points", "time")
 
 ACTIONS = (
     Action("retrieve", ("project_id",), note="a project has at most one estimate", read=True),
-    Action("create", ("project_id", "name"), ("type", "description", "last_used", "external_source", "external_id")),
+    Action(
+        "create",
+        ("project_id", "name"),
+        ("type", "description", "last_used", "external_source", "external_id"),
+        note="creates the estimate only; add its values afterwards with create_points",
+    ),
     Action("update", ("project_id",), ("name", "description", "external_source", "external_id")),
     Action("delete", ("project_id",), destructive=True),
     Action("link", ("project_id", "estimate_id"), note="makes that estimate the project's active one"),

--- a/tests/test_argument_validation.py
+++ b/tests/test_argument_validation.py
@@ -163,33 +163,6 @@ def test_a_retired_name_still_works():
     assert "does not take" not in answer
 
 
-def test_a_refusal_is_flagged_as_an_error_not_a_result():
-    """The text says "Error"; the protocol has to agree.
-
-    These refusals used to come back as plain results, so a refused call was
-    indistinguishable from a successful one to anything counting failures -- including
-    the eval harness, which reported a rate of zero while the calls kept happening.
-    """
-    from fastmcp import Client
-
-    import plane_mcp.server as server_module
-
-    async def run():
-        async with Client(server_module.get_stdio_mcp()) as client:
-            return (
-                await client.call_tool("workitem", {"project_id": "p"}, raise_on_error=False),
-                await client.call_tool(
-                    "workitem", {"action": "count", "project_id": "p", "query": "x"}, raise_on_error=False
-                ),
-            )
-
-    no_action, stray = asyncio.new_event_loop().run_until_complete(run())
-    assert no_action.is_error, "a call naming no action was reported as a success"
-    assert "requires an action" in no_action.content[0].text
-    assert stray.is_error, "a call with a stray argument was reported as a success"
-    assert "does not take: query" in stray.content[0].text
-
-
 def test_every_transport_gets_the_check():
     """A transport left behind would validate on stdio and silently drop on HTTP."""
     import plane_mcp.server as server_module

--- a/tests/test_argument_validation.py
+++ b/tests/test_argument_validation.py
@@ -163,6 +163,33 @@ def test_a_retired_name_still_works():
     assert "does not take" not in answer
 
 
+def test_a_refusal_is_flagged_as_an_error_not_a_result():
+    """The text says "Error"; the protocol has to agree.
+
+    These refusals used to come back as plain results, so a refused call was
+    indistinguishable from a successful one to anything counting failures -- including
+    the eval harness, which reported a rate of zero while the calls kept happening.
+    """
+    from fastmcp import Client
+
+    import plane_mcp.server as server_module
+
+    async def run():
+        async with Client(server_module.get_stdio_mcp()) as client:
+            return (
+                await client.call_tool("workitem", {"project_id": "p"}, raise_on_error=False),
+                await client.call_tool(
+                    "workitem", {"action": "count", "project_id": "p", "query": "x"}, raise_on_error=False
+                ),
+            )
+
+    no_action, stray = asyncio.new_event_loop().run_until_complete(run())
+    assert no_action.is_error, "a call naming no action was reported as a success"
+    assert "requires an action" in no_action.content[0].text
+    assert stray.is_error, "a call with a stray argument was reported as a success"
+    assert "does not take: query" in stray.content[0].text
+
+
 def test_every_transport_gets_the_check():
     """A transport left behind would validate on stdio and silently drop on HTTP."""
     import plane_mcp.server as server_module

--- a/tests/test_argument_validation.py
+++ b/tests/test_argument_validation.py
@@ -71,6 +71,30 @@ def test_action_itself_is_never_stray(rejection):
     assert rejection("workitem", {"action": "count"}) is None
 
 
+def test_a_call_that_chose_no_action_is_told_which_actions_exist(rejection):
+    """The observed failure: three of one weak model's six errored calls omitted
+    `action`, and Pydantic's missing_argument answer names the parameter without
+    naming a single permitted value -- so the turn buys nothing."""
+    message = rejection("project", {"project_id": "p"})
+    assert message and "requires an action" in message
+    for action in action_arguments()["project"]:
+        assert action in message, f"{action} missing from the refusal"
+
+
+def test_every_resource_names_its_actions_when_none_is_chosen(rejection):
+    """A resource left out would answer the one question the caller has with silence."""
+    for tool, actions in action_arguments().items():
+        message = rejection(tool, {})
+        assert message, f"{tool} refused a call with no action without saying why"
+        for action in actions:
+            assert action in message, f"{tool} omitted {action}"
+
+
+def test_a_call_with_no_action_on_an_unknown_tool_is_left_to_the_server(rejection):
+    """The missing-action check must not claim tools this server does not own."""
+    assert rejection("not_a_tool", {}) is None
+
+
 def test_an_unknown_action_is_left_to_the_schema(rejection):
     """The Literal reports the permitted set; a second opinion here would only muddle it."""
     assert rejection("workitem", {"action": "cout", "query": "x"}) is None
@@ -117,6 +141,13 @@ def test_a_stray_argument_never_reaches_plane():
     """The 403 the credentials would earn is the proof a call got through."""
     answer = _call("workitem", {"action": "count", "project_id": "p", "query": "urgent"})
     assert "does not take: query" in answer
+    assert "403" not in answer
+
+
+def test_a_call_with_no_action_never_reaches_plane():
+    """The refusal has to replace the schema error, not arrive after a wasted call."""
+    answer = _call("workitem", {"project_id": "p"})
+    assert "requires an action" in answer
     assert "403" not in answer
 
 


### PR DESCRIPTION
## Description

Two changes to what this surface tells a caller whose call shape is wrong.

**1. A call that names no `action` is told which actions exist.**

Every tool dispatches on a required `action`. A call that omits it never reaches our code — Pydantic rejects it against the signature:

```
1 validation error for call[project]
action
  Missing required argument [type=missing_argument, input_value={'project_id': '6ccb3f8e-...4b94-8f97-57b15c264218'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.12/v/missing_argument
```

That names the parameter without naming a single permitted value, echoes the arguments back with a UUID truncated mid-value, and points an agent at a framework URL it cannot act on. `ValidateActionArguments` already runs ahead of schema validation and already holds the action table, so it answers the question instead:

```
Error: project requires an action. It takes: archive, create, delete, get_features,
list, retrieve, unarchive, update, update_features, worklog_summary.
```

Two things deliberately unchanged:

- **A present-but-wrong action still falls to the schema.** The `Literal` already reports the permitted set (`Input should be 'get_features' or 'update_features'`), and `test_an_unknown_action_is_left_to_the_schema` records that decision. Only the *missing* case was silent, which is the inconsistency this closes.
- **The 169 retired tool names are untouched.** The table is keyed by the 28 canonical names, which no alias matches, so the check declines to speak. `test_a_retired_name_is_not_checked` guards it.

**2. `project_estimate create` says where the points go.**

Passing the `points` a caller would naturally include earns `action 'create' does not take: points. It takes: description, external_id, ...` — accurate, but silent on where they belong. The module docstring and footer explain the read path (`retrieve` → `list_points` → `workitem update`); the create-then-`create_points` sequence was undocumented at the point of use.

## How it was found

A 35-task eval battery at 2 repetitions against a low-tier model (`gemini-3.6-flash-low`, Antigravity CLI). 70/70 rows passed, so nothing here costs a task — these are wasted round trips.

Of 40 errored calls across 312, **31 named no action at all**, and a large share of those sent empty arguments — `{}`. An empty-argument call is a tool being probed for its interface, and the action list is precisely the answer that probe was denied.

For context on what this class costs: the pre-consolidation 177-tool server cannot produce it, because there is no `action` parameter to omit. Consolidation removed 65% of the advertised listing (152,543 → 53,538 chars) at identical call volume and equal-or-better success, and this is its one real cost.

## Honest limits of the claim

**No measured reduction in the behaviour.** At two repetitions, calls omitting `action` went 33 → 37 with the change applied — paired 7 tasks down, 10 up, 18 unchanged, median 0. No signal. An earlier single-repetition run suggested a large effect; that was variance.

So this is justified on consistency and legibility, not on a measured win: a caller that omits `action` now receives the list it needs rather than a framework URL, and the surface stops treating the missing case differently from the wrong case. If that is not worth a merge on its own, it should not be merged.

## Not included, deliberately

An earlier commit here made these refusals report `isError`, since both refusal paths return a plain result whose text begins `"Error: "` while the protocol reports success — so roughly 47 refusals per battery were being counted as successes.

It is reverted. Its main benefit was letting the eval harness see those refusals, and that is the harness's problem to solve; it now recognises a refusal inside a successful payload directly (#200). What remained was protocol tidiness against a measured **+13% total calls, median +1 per task** — most likely a retry that a hard error invites and a guidance-shaped result does not.

Two caveats recorded on the revert commit: that cost was measured with both changes applied together, so it is not cleanly attributable to either, and the inconsistency is real and still present — the pre-consolidation server reported these same refusals as errors. Reviving it needs a measurement that isolates it.

## Test Scenarios

- Call any resource tool with `{}` — expect `requires an action` naming every action that resource offers, and no call to Plane.
- Call `workitem` with `{"action": "cout"}` — expect the unchanged `Literal` error listing valid actions.
- Call a retired name (`retrieve_work_item` with `work_item_id`) — expect it to resolve and reach Plane as before.
- Read the advertised `project_estimate` description — `create` should state that values are added with `create_points`.

Four tests added, including a sweep asserting every one of the 28 resources names its own actions when none is chosen.

`tests/` has 17 pre-existing failures on `main`, all `TypeError: 'function' object is not subscriptable` from `plane-sdk` annotating `-> list[X]` inside classes that also define a `list` method, which Python 3.14's deferred annotations (PEP 649) resolve to the method. Unrelated; the count is identical before and after, plus 4 added passes.

## References

Follows #209, found the same way. Measured with the harness in #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation messages for missing, unknown, or unsupported actions.
  * Invalid requests now return clear rejection details instead of tool errors.
* **Improvements**
  * Enhanced activity records with clearer tool, resource, and action details.
* **Documentation**
  * Clarified action validation behavior, including retired names.
  * Added guidance that estimate creation does not add values; use the points action afterward.
* **Tests**
  * Added coverage for missing actions and validation before requests reach Plane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->