### PR TITLE
fix: require a durable OAuth token store for http/sse

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -32,7 +32,11 @@ PLANE_TEST_MCP_URL=http://localhost:8211
 # ---------------------------------------------------------------------------
 # Redis / Token storage (HTTP / SSE modes)
 # ---------------------------------------------------------------------------
-# Without Redis, OAuth tokens are kept in memory and lost on restart.
+# One of the options below is required for http/sse — the server refuses to
+# start without a token store. An in-memory store is per-process, so a restart
+# makes the refresh grant answer invalid_grant and every connected client
+# erases its credentials; take it only for local development:
+# PLANE_ALLOW_EPHEMERAL_TOKEN_STORE=true
 
 # Option A — plain Redis (no auth)
 # REDIS_HOST=localhost

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ Integration tests in `tests/test_integration.py` use `FastMCP.Client` with `Stre
 | `PLANE_WORKSPACE_SLUG` | stdio | Target workspace |
 | `PLANE_BASE_URL` | all (default: https://api.plane.so) | Plane API URL |
 | `PLANE_INTERNAL_BASE_URL` | http/sse (optional) | Internal URL for server-to-server calls |
-| `REDIS_HOST` / `REDIS_PORT` | http/sse (optional) | Token storage (falls back to in-memory) |
+| `REDIS_HOST` / `REDIS_PORT` | http/sse | Token storage. Without it the server refuses to start |
+| `PLANE_ALLOW_EPHEMERAL_TOKEN_STORE` | http/sse (optional) | Accept an in-memory token store instead. Per-process, so a restart makes the refresh grant answer `invalid_grant` and every client erases its credentials — local dev only |
 | `PLANE_OAUTH_PROVIDER_*` | http/sse OAuth | OAuth client credentials and base URL |
 | `PLANE_OAUTH_ALLOWED_REDIRECT_URIS` | http/sse OAuth (optional) | Comma-separated redirect URI patterns appended to the built-in allowlist (onboard clients without a release) |
 | `LOG_USER_INFO` | all (optional, default: false) | When `true`, include user info (PII such as display name) in logs alongside the opaque user id |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Self-hosting the server itself:
 | Variable | Purpose |
 |---|---|
 | `PLANE_INTERNAL_BASE_URL` | Internal URL for server-to-server calls, preferred over `PLANE_BASE_URL` |
-| `REDIS_HOST` / `REDIS_PORT` | OAuth token storage; falls back to in-memory |
+| `REDIS_HOST` / `REDIS_PORT` | OAuth token storage. Required for http/sse — without it the server refuses to start |
+| `PLANE_ALLOW_EPHEMERAL_TOKEN_STORE` | Accept an in-memory token store instead (local dev only — clients are logged out on every restart) |
 | `PLANE_OAUTH_PROVIDER_*` | OAuth client credentials and base URL |
 | `MCP_PATH_PREFIX` | Path prefix for the HTTP routes, when mounted behind a proxy — `/plane` serves `/plane/http/mcp` |
 

--- a/plane_mcp/__main__.py
+++ b/plane_mcp/__main__.py
@@ -15,6 +15,7 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.routing import Mount
 
 from plane_mcp.server import get_header_mcp, get_oauth_mcp, get_stdio_mcp
+from plane_mcp.storage import build_token_store
 
 LOG_USER_INFO: bool = os.getenv("LOG_USER_INFO", "").lower() == "true"
 
@@ -145,11 +146,17 @@ def main() -> None:
     if server_mode == ServerMode.HTTP:
         prefix = os.getenv("MCP_PATH_PREFIX") or ""
 
-        oauth_mcp = get_oauth_mcp(prefix + "/http")
+        # One store for both OAuth mounts. They serve the same clients from the
+        # same process, so a client that registers on /http must resolve on /sse
+        # — two stores would only agree by way of a shared Redis, and would not
+        # agree at all on the in-memory one.
+        token_store = build_token_store()
+
+        oauth_mcp = get_oauth_mcp(prefix + "/http", client_storage=token_store)
         oauth_app = oauth_mcp.http_app(stateless_http=True)
         header_app = get_header_mcp().http_app(stateless_http=True)
 
-        sse_mcp = get_oauth_mcp(prefix)
+        sse_mcp = get_oauth_mcp(prefix, client_storage=token_store)
         sse_app = sse_mcp.http_app(transport="sse")
 
         # mcp_path is appended to the auth provider's base_url to form the

--- a/plane_mcp/server.py
+++ b/plane_mcp/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from fastmcp import FastMCP
+from key_value.aio.protocols import AsyncKeyValue
 from mcp.types import Icon
 
 from plane_mcp.auth import PlaneHeaderAuthProvider, PlaneOAuthProvider
@@ -60,8 +61,14 @@ def _configured(mcp: FastMCP) -> FastMCP:
     return mcp
 
 
-def get_oauth_mcp(base_path: str = "/") -> FastMCP:
-    """Build the FastMCP instance for the OAuth HTTP / SSE transports."""
+def get_oauth_mcp(base_path: str = "/", client_storage: AsyncKeyValue | None = None) -> FastMCP:
+    """Build the FastMCP instance for the OAuth HTTP / SSE transports.
+
+    ``client_storage`` is the OAuth state store. The HTTP transport builds two
+    of these instances (``/http`` and ``/sse``) and they must share one store,
+    so a caller that builds more than one passes the store in; omitting it
+    builds a private one, which is only right for a single instance.
+    """
     oauth_mcp = FastMCP(
         "Plane MCP Server",
         instructions=SERVER_INSTRUCTIONS,
@@ -74,7 +81,7 @@ def get_oauth_mcp(base_path: str = "/") -> FastMCP:
             plane_base_url=os.getenv("PLANE_BASE_URL", ""),
             plane_internal_base_url=os.getenv("PLANE_INTERNAL_BASE_URL", ""),
             enable_cimd=os.getenv("PLANE_OAUTH_PROVIDER_ENABLE_CIMD", "false").lower() == "true",
-            client_storage=build_token_store(),
+            client_storage=client_storage if client_storage is not None else build_token_store(),
             required_scopes=["read", "write"],
             allowed_client_redirect_uris=get_allowed_client_redirect_uris(),
         ),

--- a/plane_mcp/storage.py
+++ b/plane_mcp/storage.py
@@ -8,10 +8,17 @@ HTTP / SSE transports. Priority order (highest first):
    (``AWS_CONTAINER_CREDENTIALS_FULL_URI``) + host/port → Redis with a rotating
    AUTH token from AWS Secrets Manager.
 3. ``REDIS_HOST`` + ``REDIS_PORT`` → plain Redis (no auth).
-4. None of the above → in-memory store (dev only; tokens lost on restart).
+4. None of the above → refuses to start, unless
+   ``PLANE_ALLOW_EPHEMERAL_TOKEN_STORE`` opts in to an in-memory store.
 
 Misconfigurations raise ``RuntimeError`` at startup. Reachability is verified
 eagerly with a synchronous PING.
+
+The in-memory store is not a safe default: it is per-process, so a restart or a
+second replica loses the OAuth state behind tokens clients still hold, and the
+refresh grant then answers ``invalid_grant`` — which makes clients erase their
+credentials. That reads to the user as being logged out for no reason, so it is
+opt-in rather than a fallback.
 """
 
 from __future__ import annotations
@@ -24,6 +31,15 @@ from key_value.aio.stores.memory import MemoryStore
 from key_value.aio.stores.redis import RedisStore
 
 logger = get_logger(__name__)
+
+
+# Opt-in for the in-memory store. Named for what it costs, not what it enables.
+ALLOW_MEMORY_STORE_ENV = "PLANE_ALLOW_EPHEMERAL_TOKEN_STORE"
+
+
+def _memory_store_allowed() -> bool:
+    """True when the caller has explicitly accepted a store lost on restart."""
+    return os.getenv(ALLOW_MEMORY_STORE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _has_aws_credentials() -> bool:
@@ -98,7 +114,7 @@ def build_token_store() -> Any:
         # static-password deployments. Set REDIS_SSL=true for TLS-fronted Redis.
         use_ssl = _redis_ssl_enabled(default=False)
         _ping_redis(redis_host, int(redis_port), password=password, ssl=use_ssl)
-        store = RedisStore(host=redis_host, port=int(redis_port), password=password)
+        store = RedisStore(host=redis_host, port=int(redis_port), password=password, ssl=use_ssl)
         logger.info(
             "Token store: Redis (auth=password, host=%s, port=%s, ssl=%s)",
             redis_host,
@@ -161,6 +177,26 @@ def build_token_store() -> Any:
         logger.info("Token store: Redis (auth=none, host=%s, port=%s)", redis_host, redis_port)
         return store
 
-    # 4. In-memory fallback
-    logger.warning("Token store: in-memory (tokens lost on restart). Set REDIS_HOST and REDIS_PORT for production.")
+    # 4. In-memory — opt-in only.
+    #
+    # This store is per-process, so every restart drops the OAuth state behind
+    # tokens clients still hold: the JTI mapping vanishes and the refresh grant
+    # answers invalid_grant, which is one of the three codes that make a client
+    # erase its credentials. The user sees "logged out", with no way to tell it
+    # from a real revocation. A warning is too quiet for that, so http/sse
+    # refuse to start rather than serve auth that dies at the next deploy.
+    if not _memory_store_allowed():
+        raise RuntimeError(
+            "No token store configured. The HTTP/SSE transports keep OAuth state "
+            "(client registrations, token mappings) in this store, and an in-memory "
+            "one is lost on every restart — clients are silently logged out. "
+            "Set REDIS_HOST and REDIS_PORT, or set "
+            f"{ALLOW_MEMORY_STORE_ENV}=true to accept that for local development."
+        )
+
+    logger.warning(
+        "Token store: in-memory (%s=true). Tokens are lost on restart and are not "
+        "shared between processes — never use this in production.",
+        ALLOW_MEMORY_STORE_ENV,
+    )
     return MemoryStore()

--- a/tests/test_aws_secrets.py
+++ b/tests/test_aws_secrets.py
@@ -20,7 +20,7 @@ from key_value.aio.stores.redis import RedisStore
 
 from plane_mcp import aws_secrets, storage
 from plane_mcp.aws_secrets import ElastiCacheCredentialProvider, get_secret
-from plane_mcp.storage import build_token_store
+from plane_mcp.storage import ALLOW_MEMORY_STORE_ENV, build_token_store
 
 ARN = "arn:aws:secretsmanager:us-east-1:123456789012:secret:test"
 REGION = "us-east-1"
@@ -254,8 +254,46 @@ def test_credential_provider_missing_key_raises(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_build_token_store_no_env_returns_memory_store():
+def test_build_token_store_no_env_refuses_to_start(monkeypatch):
+    """An unconfigured store is a silent logout machine, so it must not be a default.
+
+    In-memory state dies with the process; the refresh grant then answers
+    invalid_grant and every connected client erases its credentials.
+    """
+    monkeypatch.delenv(ALLOW_MEMORY_STORE_ENV, raising=False)
+    with pytest.raises(RuntimeError, match="No token store configured"):
+        build_token_store()
+
+
+def test_build_token_store_memory_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.setenv(ALLOW_MEMORY_STORE_ENV, "true")
     assert isinstance(build_token_store(), MemoryStore)
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "", "  "])
+def test_build_token_store_memory_opt_in_rejects_non_truthy(monkeypatch, value):
+    monkeypatch.setenv(ALLOW_MEMORY_STORE_ENV, value)
+    with pytest.raises(RuntimeError, match="No token store configured"):
+        build_token_store()
+
+
+def test_build_token_store_password_branch_propagates_tls_to_the_store(monkeypatch, no_ping):
+    """REDIS_SSL reached the PING and the log line but not the store itself.
+
+    The startup PING then succeeded over TLS while every subsequent store
+    operation dialled plaintext — auth that fails only after boot looks fine.
+    """
+    monkeypatch.setenv("REDIS_HOST", "localhost")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+    monkeypatch.setenv("REDIS_PASSWORD", "pw")
+    monkeypatch.setenv("REDIS_SSL", "true")
+    _forbid_boto3_secretsmanager(monkeypatch)
+
+    store = build_token_store()
+
+    assert store._client.connection_pool.connection_class.__name__ == "SSLConnection", (
+        "REDIS_SSL=true must reach RedisStore, not just the startup PING"
+    )
 
 
 def test_build_token_store_host_port_only_returns_redis(monkeypatch, no_ping):


### PR DESCRIPTION
## Why

Users connecting Claude Code to the MCP server over OAuth get logged out after a
few hours. Investigating that turned up two independent causes; this PR closes
the second one and a bug next to it.

The token store holds the state *behind* the tokens clients already hold — the
DCR client registration and the JTI mappings. Losing it doesn't expire a
session, it strands one. The refresh grant then answers `invalid_grant`, or
`invalid_client` once the registration is gone too, and those are two of the
three codes that make a compliant MCP client **erase its stored credentials**
rather than retry. The user is logged out with nothing to distinguish it from a
real revocation.

Reproduced against the pinned fastmcp 3.2.0 with a stub upstream:

```
[D] after restart, get_client()                 -> None   (=> invalid_client)
    after restart, load_access_token(valid JWT) -> None   (=> 401)
```

`REDIS_HOST`/`REDIS_PORT` are optional today and set nowhere in the Dockerfile,
README, or CI — so the in-memory fallback is what a default deployment gets,
announced only by a `logger.warning` at boot.

## What changed

**`storage.py` — the in-memory fallback is now opt-in, not a fallback.**
http/sse refuse to start without a store that survives the process. Set
`PLANE_ALLOW_EPHEMERAL_TOKEN_STORE=true` to accept the trade locally.

**`storage.py` — `REDIS_SSL` now reaches `RedisStore`.** It reached the startup
PING and the log line but not the store. Against a TLS-only Redis that is the
worst shape a misconfiguration can take: the eager PING succeeds, boot looks
healthy, the log says `ssl=True`, and every store operation afterwards dials
plaintext and fails.

**`server.py` / `__main__.py` — one store, shared.** It was built once per
`get_oauth_mcp()` call and `__main__` calls it twice, so `/http` and `/sse` each
held their own. Under Redis they happened to converge on one keyspace; under the
in-memory store they never agreed at all.

## Deploy note

⚠️ **This makes the next http/sse deploy fail if `REDIS_HOST`/`REDIS_PORT` aren't
set.** That's the intent — but the env has to be set first. Startup now prints
either `Token store: Redis (...)` or refuses outright, which also makes the
first diagnostic question answerable from the boot log.

## Tests

```
18 failed, 1170 passed, 25 skipped
baseline on clean main: 18 failed, 1163 passed
```

Same 18 pre-existing failures (all in `tests/tools/`, unrelated to this path),
+7 new tests, no regressions. `ruff check` and `ruff format --check` clean.

The test that pinned the old fallback now pins the refusal. New coverage for the
opt-in, for non-truthy opt-in values, and for TLS reaching the store — that last
one was verified to fail without the fix.

## Not in this PR

The primary cause is separate: `PlaneOAuthTokenVerifier.verify_token` makes two
uncached Plane API calls per MCP request and turns any transient failure into a
401, which the client answers with a refresh, which `proxy.py:1268-1270` reports
as `invalid_grant` — same credential erasure, no restart required. That is what
`fix-oauth-timeout-error` addresses, and it should land too.

https://claude.ai/code/session_01GkDqALzi8u1FZcMybxqBoQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP and SSE connections now share OAuth registrations, improving consistency across transport methods.
  * Added an explicit option to enable in-memory token storage for local development.

* **Bug Fixes**
  * Applications now use the configured Redis SSL setting for password-based token storage.

* **Documentation**
  * Clarified Redis requirements, startup behavior, and the restart-related limitations of ephemeral storage.

* **Tests**
  * Added coverage for token-store configuration, opt-in validation, and Redis SSL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->