### PR TITLE
feat: accept REDIS_URL for token storage; align tool annotations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Integration tests in `tests/test_integration.py` use `FastMCP.Client` with `Stre
 | `PLANE_WORKSPACE_SLUG` | stdio | Target workspace |
 | `PLANE_BASE_URL` | all (default: https://api.plane.so) | Plane API URL |
 | `PLANE_INTERNAL_BASE_URL` | http/sse (optional) | Internal URL for server-to-server calls |
+| `REDIS_URL` | http/sse (optional) | Token storage as one connection URL (`redis://`/`rediss://`); wins over host/port |
 | `REDIS_HOST` / `REDIS_PORT` | http/sse (optional) | Token storage (falls back to in-memory) |
 | `PLANE_OAUTH_PROVIDER_*` | http/sse OAuth | OAuth client credentials and base URL |
 | `PLANE_OAUTH_ALLOWED_REDIRECT_URIS` | http/sse OAuth (optional) | Comma-separated redirect URI patterns appended to the built-in allowlist (onboard clients without a release) |

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Self-hosting the server itself:
 | Variable | Purpose |
 |---|---|
 | `PLANE_INTERNAL_BASE_URL` | Internal URL for server-to-server calls, preferred over `PLANE_BASE_URL` |
+| `REDIS_URL` | OAuth token storage as one connection URL (`redis://` or `rediss://` for TLS); wins over host/port |
 | `REDIS_HOST` / `REDIS_PORT` | OAuth token storage; falls back to in-memory |
 | `PLANE_OAUTH_PROVIDER_*` | OAuth client credentials and base URL |
 | `MCP_PATH_PREFIX` | Path prefix for the HTTP routes, when mounted behind a proxy — `/plane` serves `/plane/http/mcp` |

--- a/plane_mcp/storage.py
+++ b/plane_mcp/storage.py
@@ -3,12 +3,16 @@
 Selects and verifies the storage backing the OAuth token cache used by the
 HTTP / SSE transports. Priority order (highest first):
 
-1. ``REDIS_PASSWORD`` + ``REDIS_HOST``/``REDIS_PORT`` → Redis with a static password.
-2. ``ELASTICACHE_SECRET_ARN`` + IRSA (``AWS_ROLE_ARN``) or EKS Pod Identity
+1. ``REDIS_URL`` → Redis from a single connection URL. The URL carries host,
+   port, db, credentials and TLS (``rediss://``) in one value; ``REDIS_SSL``
+   is ignored here because the scheme already decides. ``REDIS_PASSWORD``
+   applies only when the URL itself carries no password.
+2. ``REDIS_PASSWORD`` + ``REDIS_HOST``/``REDIS_PORT`` → Redis with a static password.
+3. ``ELASTICACHE_SECRET_ARN`` + IRSA (``AWS_ROLE_ARN``) or EKS Pod Identity
    (``AWS_CONTAINER_CREDENTIALS_FULL_URI``) + host/port → Redis with a rotating
    AUTH token from AWS Secrets Manager.
-3. ``REDIS_HOST`` + ``REDIS_PORT`` → plain Redis (no auth).
-4. None of the above → in-memory store (dev only; tokens lost on restart).
+4. ``REDIS_HOST`` + ``REDIS_PORT`` → plain Redis (no auth).
+5. None of the above → in-memory store (dev only; tokens lost on restart).
 
 Misconfigurations raise ``RuntimeError`` at startup. Reachability is verified
 eagerly with a synchronous PING.
@@ -18,6 +22,7 @@ from __future__ import annotations
 
 import os
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 from fastmcp.utilities.logging import get_logger
 from key_value.aio.stores.memory import MemoryStore
@@ -37,6 +42,54 @@ def _redis_ssl_enabled(default: bool) -> bool:
     if raw is None:
         return default
     return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _redact_url(url: str) -> str:
+    """The URL with any password replaced, safe to log."""
+    parsed = urlparse(url)
+    if not parsed.password:
+        return url
+    netloc = f"{parsed.username or ''}:***@{parsed.hostname}" + (f":{parsed.port}" if parsed.port else "")
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _url_password_override(url: str, password: str | None) -> dict[str, str]:
+    """Extra client kwargs for a URL-configured connection.
+
+    The URL's own credentials win; ``REDIS_PASSWORD`` fills in only when the
+    URL carries none. Returned as kwargs rather than a value so an absent
+    override cannot clobber a URL-embedded password with ``None``.
+    """
+    if password and not urlparse(url).password:
+        return {"password": password}
+    return {}
+
+
+def _ping_redis_url(url: str, *, password: str | None = None, timeout_seconds: float = 5.0) -> None:
+    """Verify Redis reachability from a connection URL with a one-shot PING.
+
+    ``redis.Redis.from_url`` honours the scheme (``rediss://`` enables TLS)
+    and any query parameters. Raises ``RuntimeError`` on failure.
+    """
+    import redis  # local: only loaded when Redis is configured
+
+    client = redis.Redis.from_url(
+        url,
+        socket_connect_timeout=timeout_seconds,
+        socket_timeout=timeout_seconds,
+        **_url_password_override(url, password),
+    )
+    try:
+        client.ping()
+    except Exception as exc:
+        raise RuntimeError(f"Redis connection failed during startup PING: {exc}") from exc
+    finally:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+    logger.info("Redis connection verified (PING succeeded)")
 
 
 def _ping_redis(
@@ -80,12 +133,36 @@ def build_token_store() -> Any:
     See the module docstring for the selection priority. The returned object
     is handed verbatim to ``PlaneOAuthProvider`` as ``client_storage``.
     """
+    redis_url = os.getenv("REDIS_URL")
     redis_host = os.getenv("REDIS_HOST")
     redis_port = os.getenv("REDIS_PORT")
     password = os.getenv("REDIS_PASSWORD")
     secret_arn = os.getenv("ELASTICACHE_SECRET_ARN")
 
-    # 1. Static-password Redis
+    # 1. Redis by connection URL
+    if redis_url:
+        if secret_arn:
+            logger.warning("Both REDIS_URL and ELASTICACHE_SECRET_ARN set — the URL wins, Secrets Manager ignored.")
+        if redis_host or redis_port:
+            logger.warning("Both REDIS_URL and REDIS_HOST/REDIS_PORT set — the URL wins, host/port ignored.")
+
+        _ping_redis_url(redis_url, password=password)
+
+        # Not RedisStore(url=...): its own URL parser keeps host/port/db but
+        # drops the scheme, silently downgrading rediss:// to plaintext.
+        # redis-py's from_url honours the scheme and query parameters.
+        from redis.asyncio import Redis as AsyncRedis
+
+        async_client = AsyncRedis.from_url(
+            redis_url,
+            decode_responses=True,
+            **_url_password_override(redis_url, password),
+        )
+        store = RedisStore(client=async_client)
+        logger.info("Token store: Redis (url=%s)", _redact_url(redis_url))
+        return store
+
+    # 2. Static-password Redis
     if password:
         if not (redis_host and redis_port):
             raise RuntimeError("REDIS_PASSWORD is set but REDIS_HOST/REDIS_PORT are not — set both to use Redis.")
@@ -107,7 +184,7 @@ def build_token_store() -> Any:
         )
         return store
 
-    # 2. ElastiCache + Secrets Manager
+    # 3. ElastiCache + Secrets Manager
     if secret_arn and _has_aws_credentials():
         if not (redis_host and redis_port):
             raise RuntimeError(
@@ -154,13 +231,15 @@ def build_token_store() -> Any:
             "skipping Secrets Manager auth."
         )
 
-    # 3. Plain Redis
+    # 4. Plain Redis
     if redis_host and redis_port:
         _ping_redis(redis_host, int(redis_port))
         store = RedisStore(host=redis_host, port=int(redis_port))
         logger.info("Token store: Redis (auth=none, host=%s, port=%s)", redis_host, redis_port)
         return store
 
-    # 4. In-memory fallback
-    logger.warning("Token store: in-memory (tokens lost on restart). Set REDIS_HOST and REDIS_PORT for production.")
+    # 5. In-memory fallback
+    logger.warning(
+        "Token store: in-memory (tokens lost on restart). Set REDIS_URL or REDIS_HOST and REDIS_PORT for production."
+    )
     return MemoryStore()

--- a/plane_mcp/toolkit/spec.py
+++ b/plane_mcp/toolkit/spec.py
@@ -26,6 +26,7 @@ class Action:
     note: str = ""
     read: bool = False
     destructive: bool = False
+    open_world: bool = False
 
     def line(self) -> str:
         """One rendered line of the tool description."""
@@ -58,7 +59,10 @@ def build_annotations(title: str, actions: tuple[Action, ...]) -> ToolAnnotation
         readOnlyHint=all(action.read for action in actions),
         destructiveHint=any(action.destructive for action in actions),
         idempotentHint=False,
-        openWorldHint=True,
+        # Nearly every action acts only on the caller's own Plane workspace
+        # through the authenticated API -- a closed domain. An action reaching
+        # beyond it (fetching a caller-supplied URL, say) declares open_world.
+        openWorldHint=any(action.open_world for action in actions),
     )
 
 

--- a/plane_mcp/tools/collection.py
+++ b/plane_mcp/tools/collection.py
@@ -65,6 +65,7 @@ ACTIONS = (
         "remove_page",
         ("collection_id", "page_collection_id"),
         note="page_collection_id is the membership id from list_pages, not the page id; the page itself is kept",
+        destructive=True,
     ),
     Action("list_members", ("collection_id",), read=True),
     Action("add_member", ("collection_id", "user_id", "member_access")),
@@ -73,6 +74,7 @@ ACTIONS = (
         "remove_member",
         ("collection_id", "collection_member_id"),
         note="collection_member_id is the membership id from list_members, not the user id",
+        destructive=True,
     ),
 )
 

--- a/plane_mcp/tools/workitem_attachment.py
+++ b/plane_mcp/tools/workitem_attachment.py
@@ -42,7 +42,7 @@ ACTIONS = (
         read=True,
     ),
     Action("download_url", ("project_id", "workitem_id", "attachment_id"), read=True),
-    Action("upload_from_url", ("project_id", "workitem_id", "url"), ("name",)),
+    Action("upload_from_url", ("project_id", "workitem_id", "url"), ("name",), open_world=True),
     Action("delete", ("project_id", "workitem_id", "attachment_id"), destructive=True),
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plane-mcp-server"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Model Context Protocol server for Plane integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_aws_secrets.py
+++ b/tests/test_aws_secrets.py
@@ -46,6 +46,7 @@ def _reset_state(monkeypatch):
     aws_secrets._SECRET_CACHE.clear()
 
     for k in (
+        "REDIS_URL",
         "REDIS_HOST",
         "REDIS_PORT",
         "REDIS_PASSWORD",
@@ -109,6 +110,7 @@ def _forbid_boto3_secretsmanager(monkeypatch) -> None:
 def no_ping(monkeypatch):
     """Skip the synchronous Redis PING so store-resolution tests need no Redis."""
     monkeypatch.setattr(storage, "_ping_redis", lambda *a, **kw: None)
+    monkeypatch.setattr(storage, "_ping_redis_url", lambda *a, **kw: None)
 
 
 @pytest.fixture
@@ -263,6 +265,65 @@ def test_build_token_store_host_port_only_returns_redis(monkeypatch, no_ping):
     monkeypatch.setenv("REDIS_PORT", "6379")
     _forbid_boto3_secretsmanager(monkeypatch)
     assert isinstance(build_token_store(), RedisStore)
+
+
+def test_build_token_store_url_returns_redis(monkeypatch, no_ping):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    _forbid_boto3_secretsmanager(monkeypatch)
+    assert isinstance(build_token_store(), RedisStore)
+
+
+def test_build_token_store_url_wins_over_host_port(monkeypatch, no_ping, capture_log):
+    caplog = capture_log("fastmcp.plane_mcp.storage")
+    monkeypatch.setenv("REDIS_URL", "redis://url-host:6390/2")
+    monkeypatch.setenv("REDIS_HOST", "other-host")
+    monkeypatch.setenv("REDIS_PORT", "6379")
+
+    store = build_token_store()
+
+    assert isinstance(store, RedisStore)
+    kwargs = store._client.connection_pool.connection_kwargs
+    assert kwargs["host"] == "url-host"
+    assert kwargs["port"] == 6390
+    assert kwargs["db"] == 2
+    assert any("host/port ignored" in rec.message for rec in caplog.records)
+
+
+def test_build_token_store_url_wins_over_arn(monkeypatch, no_ping, capture_log):
+    caplog = capture_log("fastmcp.plane_mcp.storage")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("ELASTICACHE_SECRET_ARN", ARN)
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123:role/test")
+    _forbid_boto3_secretsmanager(monkeypatch)
+
+    assert isinstance(build_token_store(), RedisStore)
+    assert any("Secrets Manager ignored" in rec.message for rec in caplog.records)
+
+
+def test_build_token_store_rediss_url_enables_tls(monkeypatch, no_ping):
+    monkeypatch.setenv("REDIS_URL", "rediss://:pw@localhost:6379/0")
+    store = build_token_store()
+    assert store._client.connection_pool.connection_class.__name__ == "SSLConnection"
+
+
+def test_build_token_store_url_password_env_fills_gap(monkeypatch, no_ping):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("REDIS_PASSWORD", "env-pw")
+    store = build_token_store()
+    assert store._client.connection_pool.connection_kwargs["password"] == "env-pw"
+
+
+def test_build_token_store_url_own_password_beats_env(monkeypatch, no_ping):
+    monkeypatch.setenv("REDIS_URL", "redis://:url-pw@localhost:6379/0")
+    monkeypatch.setenv("REDIS_PASSWORD", "env-pw")
+    store = build_token_store()
+    assert store._client.connection_pool.connection_kwargs["password"] == "url-pw"
+
+
+def test_redact_url_hides_password():
+    assert storage._redact_url("redis://user:pw@host:6379/0") == "redis://user:***@host:6379/0"
+    assert storage._redact_url("rediss://:pw@host:6380") == "rediss://:***@host:6380"
+    assert storage._redact_url("redis://host:6379/0") == "redis://host:6379/0"
 
 
 def test_build_token_store_password_wins_over_arn(monkeypatch, no_ping, capture_log):

--- a/uv.lock
+++ b/uv.lock
@@ -894,7 +894,7 @@ wheels = [
 
 [[package]]
 name = "plane-mcp-server"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -920,7 +920,7 @@ requires-dist = [
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.32.1,<2.35.0" },
     { name = "fastmcp", specifier = "==3.2.0" },
     { name = "mcp", specifier = "==1.26.0" },
-    { name = "plane-sdk", directory = "/Users/akhilvamshikonam/Documents/plane-python-sdk" },
+    { name = "plane-sdk", specifier = "==0.2.23" },
     { name = "py-key-value-aio", extras = ["redis"], specifier = ">=0.4.4,<0.5.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -931,20 +931,15 @@ provides-extras = ["dev"]
 [[package]]
 name = "plane-sdk"
 version = "0.2.23"
-source = { directory = "/Users/akhilvamshikonam/Documents/plane-python-sdk" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = ">=2.4.0" },
-    { name = "pytest", marker = "extra == 'dev'" },
-    { name = "pytest-dependency", marker = "extra == 'dev'" },
-    { name = "requests", specifier = ">=2.31.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/7e/89/c683207e50f641843273de4e19ac88154bdc89c522ec2cdab956201a4d1e/plane_sdk-0.2.23.tar.gz", hash = "sha256:aee2f3da583459b6a513f9200f703fac1942ea65c27dd6f6dd76872677535bd7", size = 102738, upload-time = "2026-08-20T10:35:34.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/38/6d7f7292025806b56655e38c6df3156b3a0ecac055d8dc0ef229fe30f1bb/plane_sdk-0.2.23-py3-none-any.whl", hash = "sha256:b2cdb86943f2cee43d066dce0e8af2b9fb955db757c4666b1a269e7c81d381c0", size = 147179, upload-time = "2026-08-20T10:35:33.017Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "platformdirs"


### PR DESCRIPTION
## What does this PR do?

Two changes:

**1. `REDIS_URL` support for OAuth token storage**

Some customers hand out a single Redis connection URL rather than a host/port pair. `REDIS_URL` is now the highest-priority storage backend:

- The URL carries host, port, db, credentials and TLS (`rediss://`) in one value; `REDIS_SSL` is ignored on this path because the scheme already decides.
- `REDIS_PASSWORD` still applies when the URL itself carries no password; a URL-embedded password wins.
- `REDIS_HOST`/`REDIS_PORT` and `ELASTICACHE_SECRET_ARN` are ignored with a warning when the URL is set.
- The client is built with redis-py's `from_url`, not `RedisStore(url=...)`: the store's own URL parser keeps host/port/db but drops the scheme, silently downgrading `rediss://` to plaintext. A test pins the TLS behavior.
- Startup PING verification and password-redacted logging match the existing paths.

**2. Tool annotation alignment**

- `openWorldHint` is now derived per action instead of hardcoded `True`: 29 of 30 tools advertise `False` (each acts only on the caller's own Plane workspace through the authenticated API — a closed domain), while `workitem_attachment` stays `True` because `upload_from_url` fetches a caller-supplied public URL.
- `collection.remove_page` / `remove_member` are now flagged destructive, matching the codebase's precedent that permanently dropping an association record is destructive (`page.detach_from_workitem`, `workitem_link.delete`). Tool-level annotations are unchanged in shape.

## How was it tested?

- Full offline suite: 1188 passed, 25 skipped (includes 7 new tests covering URL selection, precedence warnings, `rediss://` TLS, both password-override directions, and log redaction).
- `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LpufP2S3yx7d1n9n93RYQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redis token storage now supports a single `REDIS_URL`, including TLS connections, query parameters, and password fallback.
  - Redis URL configuration takes precedence over separate host/port or managed-secret settings.
  - Action metadata now accurately identifies open-world and destructive operations.

- **Documentation**
  - Added `REDIS_URL` configuration guidance to the environment variable and self-hosting documentation.

- **Chores**
  - Bumped the project version to 0.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->